### PR TITLE
Feat: DB 연동 및 카카오 소셜 로그인 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### ENV ###
+env.properties

--- a/build.gradle
+++ b/build.gradle
@@ -28,12 +28,14 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'com.cloudinary:cloudinary-taglib:1.5.0'
 	implementation 'com.cloudinary:cloudinary-http44:1.5.0'
+	implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/backend/doyouhave/config/JpaConfig.java
+++ b/src/main/java/com/backend/doyouhave/config/JpaConfig.java
@@ -1,9 +1,56 @@
 package com.backend.doyouhave.config;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableJpaAuditing
+@RequiredArgsConstructor
+@EnableWebSecurity  //Spring Security 설정 활성화
 public class JpaConfig {
+
+    @Bean
+    public WebSecurityCustomizer configure() {
+        return (web) -> web.ignoring().mvcMatchers(
+                "/v3/api-docs/**",
+                "/swagger-ui/**",
+                "/*"
+        );
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf()
+                .disable()
+                .authorizeRequests()
+                .antMatchers(HttpMethod.DELETE)
+                .hasRole("ADMIN")
+                .antMatchers("/admin/**")
+                .hasAnyRole("ADMIN")
+                .antMatchers("/user/**")
+                .hasAnyRole("USER", "ADMIN")
+                .antMatchers("/login/**")
+                .anonymous()
+                .anyRequest()
+                .authenticated()
+                .and()
+                .httpBasic()
+                .and()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+
+        return http.build();
+    }
+
+
+
 }

--- a/src/main/java/com/backend/doyouhave/config/JpaConfig.java
+++ b/src/main/java/com/backend/doyouhave/config/JpaConfig.java
@@ -14,43 +14,5 @@ import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableJpaAuditing
-@RequiredArgsConstructor
-@EnableWebSecurity  //Spring Security 설정 활성화
 public class JpaConfig {
-
-    @Bean
-    public WebSecurityCustomizer configure() {
-        return (web) -> web.ignoring().mvcMatchers(
-                "/v3/api-docs/**",
-                "/swagger-ui/**",
-                "/*"
-        );
-    }
-
-    @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.csrf()
-                .disable()
-                .authorizeRequests()
-                .antMatchers(HttpMethod.DELETE)
-                .hasRole("ADMIN")
-                .antMatchers("/admin/**")
-                .hasAnyRole("ADMIN")
-                .antMatchers("/user/**")
-                .hasAnyRole("USER", "ADMIN")
-                .antMatchers("/login/**")
-                .anonymous()
-                .anyRequest()
-                .authenticated()
-                .and()
-                .httpBasic()
-                .and()
-                .sessionManagement()
-                .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
-
-        return http.build();
-    }
-
-
-
 }

--- a/src/main/java/com/backend/doyouhave/controller/UserController.java
+++ b/src/main/java/com/backend/doyouhave/controller/UserController.java
@@ -1,0 +1,33 @@
+package com.backend.doyouhave.controller;
+
+import com.backend.doyouhave.domain.post.Post;
+import com.backend.doyouhave.domain.post.dto.PostRequestDto;
+import com.backend.doyouhave.domain.post.dto.PostResponseDto;
+import com.backend.doyouhave.domain.user.Role;
+import com.backend.doyouhave.domain.user.User;
+import com.backend.doyouhave.domain.user.dto.LoginRequestDto;
+import com.backend.doyouhave.domain.user.dto.LoginResponseDto;
+import com.backend.doyouhave.service.PostService;
+import com.backend.doyouhave.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.io.IOException;
+import java.net.URI;
+
+@RequiredArgsConstructor
+@RequestMapping("api/users")
+@RestController
+public class UserController {
+    private final UserService userService;
+
+    @PostMapping("/kakao-login")
+    public LoginResponseDto loginUser(@RequestBody LoginRequestDto request) {
+        System.out.println("code = " + request.getCode());
+        return userService.signup(Role.KAKAO, request.getCode());
+
+    }
+}

--- a/src/main/java/com/backend/doyouhave/domain/user/Role.java
+++ b/src/main/java/com/backend/doyouhave/domain/user/Role.java
@@ -1,0 +1,14 @@
+package com.backend.doyouhave.domain.user;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+    KAKAO("KAKAO"),
+    NAVER("NAVER"),
+    ADMIN("ADMIN");
+
+    private final String value;
+}

--- a/src/main/java/com/backend/doyouhave/domain/user/User.java
+++ b/src/main/java/com/backend/doyouhave/domain/user/User.java
@@ -1,0 +1,64 @@
+package com.backend.doyouhave.domain.user;
+
+import com.backend.doyouhave.domain.BaseTimeEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Embeddable
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+@Entity
+@Table(
+        name="Users",
+        uniqueConstraints={
+                @UniqueConstraint(
+                        columnNames={"social_id", "role"}
+                )
+        }
+)
+public class User extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(name = "social_id", nullable = false)
+    private Long socialId;
+
+    private String email;
+
+    private String img;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+    public static User createKakaoUser(Long kakaoId, String email, String img, String nickname) {
+        return User.builder()
+                .socialId(kakaoId)
+                .email(email)
+                .img(img)
+                .nickname(nickname)
+                .role(Role.KAKAO)
+                .build();
+    }
+
+    public static User createNaverUser(Long naverId, String email, String img, String nickname) {
+        return User.builder()
+                .socialId(naverId)
+                .email(email)
+                .img(img)
+                .nickname(nickname)
+                .role(Role.NAVER)
+                .build();
+    }
+}

--- a/src/main/java/com/backend/doyouhave/domain/user/dto/LoginRequestDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/user/dto/LoginRequestDto.java
@@ -1,0 +1,14 @@
+package com.backend.doyouhave.domain.user.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class LoginRequestDto {
+    @NotBlank
+    private String code;
+}

--- a/src/main/java/com/backend/doyouhave/domain/user/dto/LoginResponseDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/user/dto/LoginResponseDto.java
@@ -1,0 +1,31 @@
+package com.backend.doyouhave.domain.user.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class LoginResponseDto {
+    @NotBlank
+    private String accessToken;
+
+    @NotBlank
+    private String refreshToken;
+
+    @Builder
+    public LoginResponseDto(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+
+    public static LoginResponseDto from(String accessToken, String  refreshToken) {
+        return LoginResponseDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/backend/doyouhave/repository/user/UserRepository.java
+++ b/src/main/java/com/backend/doyouhave/repository/user/UserRepository.java
@@ -1,0 +1,11 @@
+package com.backend.doyouhave.repository.user;
+
+import com.backend.doyouhave.domain.user.Role;
+import com.backend.doyouhave.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByRoleAndSocialId(Role role, Long socialId);
+}

--- a/src/main/java/com/backend/doyouhave/service/AuthService.java
+++ b/src/main/java/com/backend/doyouhave/service/AuthService.java
@@ -1,0 +1,97 @@
+package com.backend.doyouhave.service;
+
+import com.backend.doyouhave.domain.user.User;
+import com.backend.doyouhave.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.http.*;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+@PropertySource("classpath:env.properties")
+public class AuthService {
+
+    private final UserRepository userRepository;
+    @Value("${auth.kakao.key}")
+    private String authKakaoKey;
+
+    @Value("${auth.kakao.redirecturl}")
+    private String authKakaoRedirectUrl;
+
+    public String getAccessTokenByCode(String code) {
+        String accessToken = "";
+        try{
+            HttpHeaders headers = new HttpHeaders();
+            headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+            MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+            params.add("grant_type", "authorization_code");
+            params.add("client_id", authKakaoKey);
+            params.add("redirect_uri", authKakaoRedirectUrl);
+            params.add("code", code);
+
+            RestTemplate rt = new RestTemplate();
+            rt.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+            HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest =
+                    new HttpEntity<>(params, headers);
+
+            ResponseEntity<String> response = rt.exchange(
+                    "https://kauth.kakao.com/oauth/token",
+                    HttpMethod.POST,
+                    kakaoTokenRequest,
+                    String.class
+            );
+
+            JSONParser parser = new JSONParser();
+            JSONObject elem = (JSONObject) parser.parse(response.getBody());
+            System.out.println("elem = " + elem);
+            accessToken = (String) elem.get("access_token");
+        } catch (ParseException e) {
+            throw new IllegalArgumentException(e.toString());
+        }
+        return accessToken;
+    }
+
+    public Optional<User> saveUserInfoByToken(String accessToken) {
+        try{
+            HttpHeaders headers = new HttpHeaders();
+            headers.add("Authorization", "Bearer " + accessToken);
+            headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+            RestTemplate rt = new RestTemplate();
+            rt.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+
+            HttpEntity<MultiValueMap<String, String>> kakaoProfileRequest = new HttpEntity<>(headers);
+
+            ResponseEntity<String> response = rt.exchange(
+                    "https://kapi.kakao.com/v2/user/me",
+                    HttpMethod.POST,
+                    kakaoProfileRequest,
+                    String.class
+            );
+
+            JSONParser parser = new JSONParser();
+            JSONObject elem = (JSONObject) parser.parse(response.getBody());
+            System.out.println("elem = " + elem);
+            Long id = (Long) elem.get("id");
+            String email = (String) ((JSONObject) elem.get("kakao_account")).get("email");
+            String nickname = (String) ((JSONObject) elem.get("properties")).get("nickname");
+            String img = (String) ((JSONObject) elem.get("properties")).get("profile_image");
+
+            return Optional.ofNullable(User.createKakaoUser(id, email, img, nickname));
+        } catch (ParseException e) {
+            throw new IllegalArgumentException(e.toString());
+        }
+    }
+}

--- a/src/main/java/com/backend/doyouhave/service/UserService.java
+++ b/src/main/java/com/backend/doyouhave/service/UserService.java
@@ -1,0 +1,52 @@
+package com.backend.doyouhave.service;
+
+import com.backend.doyouhave.domain.comment.dto.CommentRequestDto;
+import com.backend.doyouhave.domain.user.Role;
+import com.backend.doyouhave.domain.user.User;
+import com.backend.doyouhave.domain.user.dto.LoginResponseDto;
+import com.backend.doyouhave.repository.post.PostRepository;
+import com.backend.doyouhave.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class UserService {
+    private final UserRepository userRepository;
+    private final AuthService authService;
+
+    public LoginResponseDto signup(Role role, String code) {
+
+        if (role.equals(Role.KAKAO)) {
+            String accessToken = authService.getAccessTokenByCode(code);
+            Optional<User> kakaoUser = authService.saveUserInfoByToken(accessToken);
+            Optional<User> existUser = userRepository.findByRoleAndSocialId(Role.KAKAO, kakaoUser.get().getSocialId());
+            if(!existUser.isEmpty()){
+                // exist
+                return login(existUser.get());
+            }
+            // signup
+            userRepository.save(kakaoUser.get());
+            return login(kakaoUser.get());
+
+        } else if (role.equals(Role.NAVER)) {
+            // 미구현
+            return null;
+        }
+
+        return null;
+    }
+
+    public LoginResponseDto login(User user) {
+        // JWT 구현 예정
+
+        String accessToken = "accessToken";
+        String refreshToken = "refreshToken";
+
+        return LoginResponseDto.from(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/backend/doyouhave/util/CloudManager.java
+++ b/src/main/java/com/backend/doyouhave/util/CloudManager.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -22,6 +23,7 @@ import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
+@PropertySource("classpath:env.properties")
 public class CloudManager {
 
     private Cloudinary cloudinary;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
-
+# ??????? debug (?????? info)
+logging.level.hello.springmvc=debug
+spring.devtools.livereload.enabled=true
+spring.devtools.restart.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,3 +2,6 @@
 logging.level.hello.springmvc=debug
 spring.devtools.livereload.enabled=true
 spring.devtools.restart.enabled=true
+
+spring.security.user.name=user
+spring.security.user.password=user

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+spring:
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://localhost:5432/doyouhave
+    username: ${datasource.username}
+    password: ${datasource.password}
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    database: postgresql
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    open-in-view: false
+    generate-ddl: true


### PR DESCRIPTION
- 카카오 로그인 API를 연동해 간편 회원가입 및 로그인 기능을 구현했습니다.
  -> **클라이언트에게 인가코드를 받아 카카오 서버에 요청해 토큰 및 유저 정보를 받는 식으로 구현했습니다.**
- 비밀키는 모두 **env.properties** 파일에 등록해두었고, 해당 파일은 .gitignore에 추가했습니다. (파일은 노션에 공유해놓겠습니다.)
- Postgresql DB 연동하였습니다.
-  추후 PR 작업 목록 : 네이버 간편 로그인 연동, JWT 구현