### PR TITLE
Feat: Add Exception Handler

### DIFF
--- a/src/main/java/com/backend/doyouhave/controller/UserController.java
+++ b/src/main/java/com/backend/doyouhave/controller/UserController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import javax.validation.Valid;
 import java.io.IOException;
 import java.net.URI;
 
@@ -25,7 +26,7 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/kakao-login")
-    public LoginResponseDto loginUser(@RequestBody LoginRequestDto request) {
+    public LoginResponseDto loginUser(@RequestBody @Valid LoginRequestDto request) {
         System.out.println("code = " + request.getCode());
         return userService.signup(Role.KAKAO, request.getCode());
 

--- a/src/main/java/com/backend/doyouhave/exception/BusinessException.java
+++ b/src/main/java/com/backend/doyouhave/exception/BusinessException.java
@@ -1,0 +1,21 @@
+package com.backend.doyouhave.exception;
+
+public class BusinessException extends RuntimeException {
+
+    private final ExceptionCode errorCode;
+
+    public BusinessException(String message, ExceptionCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ExceptionCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ExceptionCode getErrorCode() {
+        return errorCode;
+    }
+
+}

--- a/src/main/java/com/backend/doyouhave/exception/ExceptionCode.java
+++ b/src/main/java/com/backend/doyouhave/exception/ExceptionCode.java
@@ -1,0 +1,26 @@
+package com.backend.doyouhave.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExceptionCode {
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "INVALID INPUT VALUE"),
+    DUPLICATED_USER(HttpStatus.BAD_REQUEST, "DUPLICATED USER"),
+    SOCIAL_LOGIN_FAIL(HttpStatus.BAD_REQUEST, "SOCIAL LOGIN FAIL"),
+
+    WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "WRONG PASSWORD"),
+    FAIL_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "FAIL AUTHENTICATION"), // 로그인X 유저의 요청
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "TOKEN EXPIRED"), // 엑세스 토큰 만료
+    FAIL_AUTHORIZATION(HttpStatus.FORBIDDEN, "FAIL AUTHORIZATION"), // 권한 없는 요청
+    JWT_EXCEPTION(HttpStatus.FORBIDDEN, "JWT EXCEPTION"), // 토큰 문제 (JWT)
+
+    NOT_FOUND(HttpStatus.NOT_FOUND, "NOT FOUND"),
+
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/backend/doyouhave/exception/ExceptionResponse.java
+++ b/src/main/java/com/backend/doyouhave/exception/ExceptionResponse.java
@@ -1,0 +1,32 @@
+package com.backend.doyouhave.exception;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExceptionResponse {
+    private String message;
+    private int status;
+
+    private ExceptionResponse(final ExceptionCode code) {
+        this.message = code.getMessage();
+        this.status = code.getStatus().value();
+    }
+
+    private ExceptionResponse(final ExceptionCode code, final String message) {
+        this.status = code.getStatus().value();
+        this.message = message;
+    }
+
+    public static ExceptionResponse of(final ExceptionCode code) {
+        return new ExceptionResponse(code);
+    }
+
+    public static ExceptionResponse of(final ExceptionCode code, final String additionalMessage) {
+        String message = String.format("%s - %s", code.getMessage(), additionalMessage);
+        return new ExceptionResponse(code, message);
+    }
+
+}

--- a/src/main/java/com/backend/doyouhave/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/backend/doyouhave/exception/GlobalExceptionHandler.java
@@ -10,14 +10,25 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    // validation 예외 발생
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ExceptionResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         log.error("MethodArgumentNotValidException", e);
-        final var response = ExceptionResponse.of(ExceptionCode.INVALID_INPUT_VALUE);
+        final ExceptionResponse response = ExceptionResponse.of(ExceptionCode.INVALID_INPUT_VALUE);
         return new ResponseEntity<>(response, ExceptionCode.INVALID_INPUT_VALUE.getStatus());
     }
 
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ExceptionResponse> handleNotFoundException(NotFoundException e) {
+        final ExceptionResponse response = ExceptionResponse.of(ExceptionCode.NOT_FOUND);
+        return new ResponseEntity<>(response, ExceptionCode.NOT_FOUND.getStatus());
+    }
+
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ExceptionResponse> handleBusinessException(final BusinessException e) {
+        log.error("BusinessException ", e);
+        final ExceptionResponse response = ExceptionResponse.of(e.getErrorCode());
+        return new ResponseEntity<>(response, e.getErrorCode().getStatus());
+    }
 
     /**
      * 예상치 못한 에러를 잡기 위해 Exception handler 정의
@@ -26,7 +37,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<ExceptionResponse> handleException(Exception e) {
         log.error("Exception", e);
-        ExceptionResponse response = ExceptionResponse.of(ExceptionCode.INTERNAL_SERVER_ERROR, e.getMessage());
+        final ExceptionResponse response = ExceptionResponse.of(ExceptionCode.INTERNAL_SERVER_ERROR, e.getMessage());
         return new ResponseEntity<>(response, ExceptionCode.INTERNAL_SERVER_ERROR.getStatus());
     }
 }

--- a/src/main/java/com/backend/doyouhave/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/backend/doyouhave/exception/GlobalExceptionHandler.java
@@ -1,0 +1,32 @@
+package com.backend.doyouhave.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // validation 예외 발생
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ExceptionResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error("MethodArgumentNotValidException", e);
+        final var response = ExceptionResponse.of(ExceptionCode.INVALID_INPUT_VALUE);
+        return new ResponseEntity<>(response, ExceptionCode.INVALID_INPUT_VALUE.getStatus());
+    }
+
+
+    /**
+     * 예상치 못한 에러를 잡기 위해 Exception handler 정의
+     * return 500 Error
+     */
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ExceptionResponse> handleException(Exception e) {
+        log.error("Exception", e);
+        ExceptionResponse response = ExceptionResponse.of(ExceptionCode.INTERNAL_SERVER_ERROR, e.getMessage());
+        return new ResponseEntity<>(response, ExceptionCode.INTERNAL_SERVER_ERROR.getStatus());
+    }
+}

--- a/src/main/java/com/backend/doyouhave/exception/JwtException.java
+++ b/src/main/java/com/backend/doyouhave/exception/JwtException.java
@@ -1,0 +1,8 @@
+package com.backend.doyouhave.exception;
+
+public class JwtException extends BusinessException {
+
+    public JwtException() {
+        super(ExceptionCode.JWT_EXCEPTION);
+    }
+}

--- a/src/main/java/com/backend/doyouhave/exception/NotFoundException.java
+++ b/src/main/java/com/backend/doyouhave/exception/NotFoundException.java
@@ -1,0 +1,8 @@
+package com.backend.doyouhave.exception;
+
+public class NotFoundException extends BusinessException {
+
+    public NotFoundException() {
+        super(ExceptionCode.NOT_FOUND);
+    }
+}


### PR DESCRIPTION
에러 반환을 명확하게 하기 위해 **Global Exception Handler**를 추가했습니다.
에러 반환 형식은 아래와 같습니다. _(message, status)_
(예시)
`{
"message":"INVALID INPUT VALUE",
"status":400
}`

#### 정의한 Exception 목록
- validation exception
- not found exception
- jwt exception
- internal server exception

자유롭게 추가해주세요~