### PR TITLE
Feat: JWT 구현 (AccessToken, RefreshToken)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'com.cloudinary:cloudinary-taglib:1.5.0'
 	implementation 'com.cloudinary:cloudinary-http44:1.5.0'
 	implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
+	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/java/com/backend/doyouhave/config/JpaConfig.java
+++ b/src/main/java/com/backend/doyouhave/config/JpaConfig.java
@@ -1,16 +1,8 @@
 package com.backend.doyouhave.config;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.http.HttpMethod;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
-import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.web.SecurityFilterChain;
+
 
 @Configuration
 @EnableJpaAuditing

--- a/src/main/java/com/backend/doyouhave/config/SecurityConfig.java
+++ b/src/main/java/com/backend/doyouhave/config/SecurityConfig.java
@@ -38,7 +38,8 @@ public class SecurityConfig {
         return (web) -> web.ignoring().mvcMatchers(
                 "/v3/api-docs/**",
                 "/swagger-ui/**",
-                "/api/users/kakao-login"
+                "/api/users/kakao-login",
+                "/api/auth/token-refresh"
         );
     }
 

--- a/src/main/java/com/backend/doyouhave/config/SecurityConfig.java
+++ b/src/main/java/com/backend/doyouhave/config/SecurityConfig.java
@@ -1,0 +1,19 @@
+package com.backend.doyouhave.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig {
+    @Bean
+    public WebSecurityCustomizer configure() {
+        return (web) -> web.ignoring().mvcMatchers(
+                "/v3/api-docs/**",
+                "/swagger-ui/**",
+                "/api/**" //임시
+        );
+    }
+}

--- a/src/main/java/com/backend/doyouhave/config/SecurityConfig.java
+++ b/src/main/java/com/backend/doyouhave/config/SecurityConfig.java
@@ -1,19 +1,84 @@
 package com.backend.doyouhave.config;
 
+import com.backend.doyouhave.domain.user.Role;
+import com.backend.doyouhave.exception.ExceptionCode;
+import com.backend.doyouhave.exception.ExceptionResponse;
+import com.backend.doyouhave.jwt.JwtAuthenticationFilter;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @RequiredArgsConstructor
 @EnableWebSecurity
 public class SecurityConfig {
+
+    private final ObjectMapper objectMapper;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public AuthenticationManager authenticationManager(
+            AuthenticationConfiguration authenticationConfiguration
+    ) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+
     @Bean
     public WebSecurityCustomizer configure() {
         return (web) -> web.ignoring().mvcMatchers(
                 "/v3/api-docs/**",
                 "/swagger-ui/**",
-                "/api/**" //임시
+                "/api/users/kakao-login"
         );
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http.csrf().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+
+                .authorizeRequests()
+                .antMatchers().permitAll()
+                .anyRequest().authenticated()
+                .and()
+
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+
+                .exceptionHandling()
+                .authenticationEntryPoint(((request, response, authException) -> {
+                    if(request.getAttribute("exception") == ExceptionCode.TOKEN_EXPIRED){
+                        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+                        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                        objectMapper.writeValue(
+                                response.getOutputStream(),
+                                ExceptionResponse.of(ExceptionCode.TOKEN_EXPIRED)
+                        );
+                    }
+                    response.setStatus(HttpStatus.UNAUTHORIZED.value());
+                    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                    objectMapper.writeValue(
+                            response.getOutputStream(),
+                            ExceptionResponse.of(ExceptionCode.FAIL_AUTHENTICATION)
+                    );
+                }))
+                .accessDeniedHandler(((request, response, accessDeniedException) -> {
+                    response.setStatus(HttpStatus.FORBIDDEN.value());
+                    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                    objectMapper.writeValue(
+                            response.getOutputStream(),
+                            ExceptionResponse.of(ExceptionCode.FAIL_AUTHORIZATION)
+                    );
+                })).and().build();
     }
 }

--- a/src/main/java/com/backend/doyouhave/config/SecurityConfig.java
+++ b/src/main/java/com/backend/doyouhave/config/SecurityConfig.java
@@ -49,6 +49,7 @@ public class SecurityConfig {
                 .and()
 
                 .authorizeRequests()
+                .antMatchers("/api/admins/**").hasRole("ADMIN")
                 .antMatchers().permitAll()
                 .anyRequest().authenticated()
                 .and()

--- a/src/main/java/com/backend/doyouhave/controller/AuthController.java
+++ b/src/main/java/com/backend/doyouhave/controller/AuthController.java
@@ -1,0 +1,28 @@
+package com.backend.doyouhave.controller;
+
+import com.backend.doyouhave.domain.user.Role;
+import com.backend.doyouhave.domain.user.dto.LoginRequestDto;
+import com.backend.doyouhave.domain.user.dto.LoginResponseDto;
+import com.backend.doyouhave.domain.user.dto.TokenRefreshRequestDto;
+import com.backend.doyouhave.service.AuthService;
+import com.backend.doyouhave.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RequiredArgsConstructor
+@RequestMapping("api/auth")
+@RestController
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/token-refresh")
+    public LoginResponseDto tokenRefresh(@RequestBody @Valid TokenRefreshRequestDto request) {
+        return authService.tokenRefresh(request.getRefreshToken());
+
+    }
+}

--- a/src/main/java/com/backend/doyouhave/controller/UserController.java
+++ b/src/main/java/com/backend/doyouhave/controller/UserController.java
@@ -1,18 +1,15 @@
 package com.backend.doyouhave.controller;
 
 import com.backend.doyouhave.domain.user.Role;
-import com.backend.doyouhave.domain.user.User;
 import com.backend.doyouhave.domain.user.dto.LoginRequestDto;
 import com.backend.doyouhave.domain.user.dto.LoginResponseDto;
+import com.backend.doyouhave.domain.user.dto.UserProfileResponseDto;
 import com.backend.doyouhave.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import java.util.Optional;
 
 @RequiredArgsConstructor
 @RequestMapping("api/users")
@@ -22,16 +19,13 @@ public class UserController {
 
     @PostMapping("/kakao-login")
     public LoginResponseDto loginUser(@RequestBody @Valid LoginRequestDto request) {
-        System.out.println("code = " + request.getCode());
         return userService.signup(Role.KAKAO, request.getCode());
 
     }
 
     @GetMapping("/profile")
-    public Boolean findUsersProfile(@AuthenticationPrincipal Long userId) {
-        System.out.println(userId);
-
-        return true;
+    public UserProfileResponseDto findUsersProfile(@AuthenticationPrincipal Long userId) {
+        return userService.findUsersProfile(userId);
 
     }
 }

--- a/src/main/java/com/backend/doyouhave/controller/UserController.java
+++ b/src/main/java/com/backend/doyouhave/controller/UserController.java
@@ -1,23 +1,18 @@
 package com.backend.doyouhave.controller;
 
-import com.backend.doyouhave.domain.post.Post;
-import com.backend.doyouhave.domain.post.dto.PostRequestDto;
-import com.backend.doyouhave.domain.post.dto.PostResponseDto;
 import com.backend.doyouhave.domain.user.Role;
 import com.backend.doyouhave.domain.user.User;
 import com.backend.doyouhave.domain.user.dto.LoginRequestDto;
 import com.backend.doyouhave.domain.user.dto.LoginResponseDto;
-import com.backend.doyouhave.service.PostService;
 import com.backend.doyouhave.service.UserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import javax.validation.Valid;
-import java.io.IOException;
-import java.net.URI;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @RequestMapping("api/users")
@@ -29,6 +24,13 @@ public class UserController {
     public LoginResponseDto loginUser(@RequestBody @Valid LoginRequestDto request) {
         System.out.println("code = " + request.getCode());
         return userService.signup(Role.KAKAO, request.getCode());
+
+    }
+
+    @GetMapping("/profile")
+    public Boolean findUsersProfile(@AuthenticationPrincipal UserDetails user) {
+        System.out.println(user);
+        return true;
 
     }
 }

--- a/src/main/java/com/backend/doyouhave/controller/UserController.java
+++ b/src/main/java/com/backend/doyouhave/controller/UserController.java
@@ -28,8 +28,9 @@ public class UserController {
     }
 
     @GetMapping("/profile")
-    public Boolean findUsersProfile(@AuthenticationPrincipal UserDetails user) {
-        System.out.println(user);
+    public Boolean findUsersProfile(@AuthenticationPrincipal Long userId) {
+        System.out.println(userId);
+
         return true;
 
     }

--- a/src/main/java/com/backend/doyouhave/domain/user/Role.java
+++ b/src/main/java/com/backend/doyouhave/domain/user/Role.java
@@ -6,9 +6,9 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum Role {
-    KAKAO("KAKAO"),
-    NAVER("NAVER"),
-    ADMIN("ADMIN");
+    KAKAO("ROLE_KAKAO"),
+    NAVER("ROLE_NAVER"),
+    ADMIN("ROLE_ADMIN");
 
     private final String value;
 }

--- a/src/main/java/com/backend/doyouhave/domain/user/User.java
+++ b/src/main/java/com/backend/doyouhave/domain/user/User.java
@@ -45,6 +45,9 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private Role role;
 
+    @Column(name = "refresh_token")
+    private String refreshToken;
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Comment> comments = new ArrayList<>();
 

--- a/src/main/java/com/backend/doyouhave/domain/user/dto/TokenRefreshRequestDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/user/dto/TokenRefreshRequestDto.java
@@ -1,0 +1,14 @@
+package com.backend.doyouhave.domain.user.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TokenRefreshRequestDto {
+    @NotBlank
+    private String refreshToken;
+}

--- a/src/main/java/com/backend/doyouhave/domain/user/dto/UserProfileResponseDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/user/dto/UserProfileResponseDto.java
@@ -1,0 +1,47 @@
+package com.backend.doyouhave.domain.user.dto;
+
+import com.backend.doyouhave.domain.user.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserProfileResponseDto {
+    @NotBlank
+    private Long userId;
+
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String img;
+
+    @NotBlank
+    private String nickname;
+
+    @NotBlank
+    private String socialType;
+
+    @Builder
+    public UserProfileResponseDto(Long userId, String email, String img, String nickname, String socialType) {
+        this.userId = userId;
+        this.email = email;
+        this.img = img;
+        this.nickname = nickname;
+        this.socialType = socialType;
+    }
+
+    public static UserProfileResponseDto from(User user) {
+        return UserProfileResponseDto.builder()
+                .userId(user.getId())
+                .email(user.getEmail())
+                .img(user.getImg())
+                .nickname(user.getNickname())
+                .socialType(user.getRole().getValue())
+                .build();
+    }
+}

--- a/src/main/java/com/backend/doyouhave/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/backend/doyouhave/exception/GlobalExceptionHandler.java
@@ -19,6 +19,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(NotFoundException.class)
     public ResponseEntity<ExceptionResponse> handleNotFoundException(NotFoundException e) {
+        log.error("NotFoundException", e);
         final ExceptionResponse response = ExceptionResponse.of(ExceptionCode.NOT_FOUND);
         return new ResponseEntity<>(response, ExceptionCode.NOT_FOUND.getStatus());
     }

--- a/src/main/java/com/backend/doyouhave/exception/SocialLoginException.java
+++ b/src/main/java/com/backend/doyouhave/exception/SocialLoginException.java
@@ -1,0 +1,8 @@
+package com.backend.doyouhave.exception;
+
+public class SocialLoginException extends BusinessException {
+
+    public SocialLoginException() {
+        super(ExceptionCode.SOCIAL_LOGIN_FAIL);
+    }
+}

--- a/src/main/java/com/backend/doyouhave/jwt/CustomUserDetailService.java
+++ b/src/main/java/com/backend/doyouhave/jwt/CustomUserDetailService.java
@@ -1,0 +1,24 @@
+package com.backend.doyouhave.jwt;
+
+import com.backend.doyouhave.domain.user.User;
+import com.backend.doyouhave.exception.NotFoundException;
+import com.backend.doyouhave.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+        User findUser = userRepository.findById(Long.parseLong(userId)).orElseThrow(() -> new NotFoundException());
+        return UserPrincipal.create(findUser);
+    }
+}

--- a/src/main/java/com/backend/doyouhave/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/backend/doyouhave/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,67 @@
+package com.backend.doyouhave.jwt;
+
+import com.backend.doyouhave.exception.ExceptionCode;
+import com.backend.doyouhave.exception.ExceptionResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@RequiredArgsConstructor
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String PREFIX_BEARER = "Bearer ";
+    private final UserDetailsService userDetailsService;
+    private final JwtTokenProvider jwtProvider;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+
+        var accessToken = resolveToken(request);
+        ExceptionCode errorCode = jwtProvider.validateToken(accessToken);
+
+        if (accessToken != null && errorCode==null) {
+            try {
+                UserDetails userDetails = userDetailsService.loadUserByUsername(String.valueOf(jwtProvider.getAccessTokenPayload(accessToken)));
+                SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(userDetails.getUsername(), "", userDetails.getAuthorities()));
+            } catch (Exception e) {
+                response.setStatus(HttpStatus.UNAUTHORIZED.value());
+                response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                objectMapper.writeValue(
+                        response.getOutputStream(),
+                        ExceptionResponse.of(ExceptionCode.FAIL_AUTHENTICATION)
+                );
+                return;
+            }
+        }
+
+        request.setAttribute("exception", errorCode);
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(PREFIX_BEARER)) {
+            return bearerToken.substring(7);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/backend/doyouhave/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/backend/doyouhave/jwt/JwtAuthenticationFilter.java
@@ -40,7 +40,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (accessToken != null && errorCode==null) {
             try {
                 UserDetails userDetails = userDetailsService.loadUserByUsername(String.valueOf(jwtProvider.getAccessTokenPayload(accessToken)));
-                SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(userDetails.getUsername(), "", userDetails.getAuthorities()));
+                SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(Long.parseLong(userDetails.getUsername()), "", userDetails.getAuthorities()));
             } catch (Exception e) {
                 response.setStatus(HttpStatus.UNAUTHORIZED.value());
                 response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/src/main/java/com/backend/doyouhave/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/backend/doyouhave/jwt/JwtAuthenticationFilter.java
@@ -28,18 +28,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final String PREFIX_BEARER = "Bearer ";
     private final UserDetailsService userDetailsService;
-    private final JwtTokenProvider jwtProvider;
+    private final JwtTokenProvider jwtTokenProvider;
     private final ObjectMapper objectMapper;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
 
         var accessToken = resolveToken(request);
-        ExceptionCode errorCode = jwtProvider.validateToken(accessToken);
+        ExceptionCode errorCode = jwtTokenProvider.validateToken(accessToken);
 
         if (accessToken != null && errorCode==null) {
             try {
-                UserDetails userDetails = userDetailsService.loadUserByUsername(String.valueOf(jwtProvider.getAccessTokenPayload(accessToken)));
+                UserDetails userDetails = userDetailsService.loadUserByUsername(String.valueOf(jwtTokenProvider.getJwtTokenPayload(accessToken)));
                 SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken(Long.parseLong(userDetails.getUsername()), "", userDetails.getAuthorities()));
             } catch (Exception e) {
                 response.setStatus(HttpStatus.UNAUTHORIZED.value());

--- a/src/main/java/com/backend/doyouhave/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/backend/doyouhave/jwt/JwtTokenProvider.java
@@ -1,0 +1,65 @@
+package com.backend.doyouhave.jwt;
+
+
+import com.backend.doyouhave.exception.ExceptionCode;
+import com.backend.doyouhave.exception.JwtException;
+import io.jsonwebtoken.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@RequiredArgsConstructor
+@Component
+@PropertySource("classpath:env.properties")
+public class JwtTokenProvider {
+
+    @Value("${auth.jwtSecret}")
+    private String jwtSecret;
+
+    @Value("${auth.jwtExpirationInMs}")
+    private int jwtExpirationInMs;
+
+    private String createToken(final long payload, final String jwtSecret, final int jwtExpirationInMs) {
+        return Jwts.builder()
+                .setSubject(String.valueOf(payload))
+                .signWith(SignatureAlgorithm.HS256, jwtSecret)
+                .setExpiration(new Date(System.currentTimeMillis() + jwtExpirationInMs))
+                .compact();
+    }
+
+    public String createAccessToken(final long payload) {
+        return createToken(payload, jwtSecret, jwtExpirationInMs);
+    }
+
+    public Long getAccessTokenPayload(String accessToken) {
+        try {
+            var claims = Jwts.parser()
+                    .setSigningKey(jwtSecret)
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+
+            return Long.parseLong(claims.getSubject());
+        } catch (ExpiredJwtException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
+            throw new JwtException();
+        }
+    }
+
+    public ExceptionCode validateToken(String accessToken) {
+        try {
+            var claims = Jwts.parser()
+                    .setSigningKey(jwtSecret)
+                    .parseClaimsJws(accessToken);
+            if(!claims.getBody().getExpiration().before(new Date()) == false) {
+                return ExceptionCode.FAIL_AUTHENTICATION;
+            }
+            return null;
+        } catch (ExpiredJwtException e){
+            return ExceptionCode.TOKEN_EXPIRED;
+        } catch (Exception e) {
+            return ExceptionCode.FAIL_AUTHENTICATION;
+        }
+    }
+}

--- a/src/main/java/com/backend/doyouhave/jwt/UserPrincipal.java
+++ b/src/main/java/com/backend/doyouhave/jwt/UserPrincipal.java
@@ -40,7 +40,7 @@ public class UserPrincipal implements UserDetails {
 
     @Override
     public String getUsername() {
-        return null;
+        return String.valueOf(userId);
     }
 
     @Override

--- a/src/main/java/com/backend/doyouhave/jwt/UserPrincipal.java
+++ b/src/main/java/com/backend/doyouhave/jwt/UserPrincipal.java
@@ -1,0 +1,65 @@
+package com.backend.doyouhave.jwt;
+
+
+import com.backend.doyouhave.domain.user.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class UserPrincipal implements UserDetails {
+
+    private final Long userId;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    public UserPrincipal(Long userId, Collection<? extends GrantedAuthority> authorities) {
+        this.userId = userId;
+        this.authorities = authorities;
+    }
+
+    public static UserPrincipal create(User user) {
+        var authorities = Collections.singletonList(new SimpleGrantedAuthority(user.getRole().getValue()));
+        return new UserPrincipal(user.getId(), authorities);
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return null;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return false;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+}

--- a/src/main/java/com/backend/doyouhave/repository/user/UserRepository.java
+++ b/src/main/java/com/backend/doyouhave/repository/user/UserRepository.java
@@ -3,9 +3,15 @@ package com.backend.doyouhave.repository.user;
 import com.backend.doyouhave.domain.user.Role;
 import com.backend.doyouhave.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByRoleAndSocialId(Role role, Long socialId);
+
+    @Query(value = "SELECT u.refresh_token FROM Users u WHERE u.user_id = :id", nativeQuery = true)
+    String findRefreshTokenById(@Param("id") Long userId);
 }

--- a/src/main/java/com/backend/doyouhave/service/AuthService.java
+++ b/src/main/java/com/backend/doyouhave/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.backend.doyouhave.service;
 
 import com.backend.doyouhave.domain.user.User;
+import com.backend.doyouhave.exception.SocialLoginException;
 import com.backend.doyouhave.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.json.simple.JSONObject;
@@ -58,8 +59,8 @@ public class AuthService {
             JSONObject elem = (JSONObject) parser.parse(response.getBody());
             System.out.println("elem = " + elem);
             accessToken = (String) elem.get("access_token");
-        } catch (ParseException e) {
-            throw new IllegalArgumentException(e.toString());
+        } catch (Exception e) {
+            throw new SocialLoginException();
         }
         return accessToken;
     }
@@ -90,8 +91,8 @@ public class AuthService {
             String img = (String) ((JSONObject) elem.get("properties")).get("profile_image");
 
             return Optional.ofNullable(User.createKakaoUser(id, email, img, nickname));
-        } catch (ParseException e) {
-            throw new IllegalArgumentException(e.toString());
+        } catch (Exception e) {
+            throw new SocialLoginException();
         }
     }
 }

--- a/src/main/java/com/backend/doyouhave/service/UserService.java
+++ b/src/main/java/com/backend/doyouhave/service/UserService.java
@@ -4,6 +4,8 @@ import com.backend.doyouhave.domain.comment.dto.CommentRequestDto;
 import com.backend.doyouhave.domain.user.Role;
 import com.backend.doyouhave.domain.user.User;
 import com.backend.doyouhave.domain.user.dto.LoginResponseDto;
+import com.backend.doyouhave.domain.user.dto.UserProfileResponseDto;
+import com.backend.doyouhave.exception.NotFoundException;
 import com.backend.doyouhave.jwt.JwtTokenProvider;
 import com.backend.doyouhave.repository.post.PostRepository;
 import com.backend.doyouhave.repository.user.UserRepository;
@@ -50,5 +52,10 @@ public class UserService {
         return LoginResponseDto.from(
                 jwtTokenProvider.createAccessToken(user.getId()),
                 refreshToken);
+    }
+
+    public UserProfileResponseDto findUsersProfile(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new NotFoundException());
+        return UserProfileResponseDto.from(user);
     }
 }

--- a/src/main/java/com/backend/doyouhave/service/UserService.java
+++ b/src/main/java/com/backend/doyouhave/service/UserService.java
@@ -4,6 +4,7 @@ import com.backend.doyouhave.domain.comment.dto.CommentRequestDto;
 import com.backend.doyouhave.domain.user.Role;
 import com.backend.doyouhave.domain.user.User;
 import com.backend.doyouhave.domain.user.dto.LoginResponseDto;
+import com.backend.doyouhave.jwt.JwtTokenProvider;
 import com.backend.doyouhave.repository.post.PostRepository;
 import com.backend.doyouhave.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +19,7 @@ import java.util.Optional;
 public class UserService {
     private final UserRepository userRepository;
     private final AuthService authService;
-
+    private final JwtTokenProvider jwtTokenProvider;
     public LoginResponseDto signup(Role role, String code) {
 
         if (role.equals(Role.KAKAO)) {
@@ -44,9 +45,10 @@ public class UserService {
     public LoginResponseDto login(User user) {
         // JWT 구현 예정
 
-        String accessToken = "accessToken";
         String refreshToken = "refreshToken";
 
-        return LoginResponseDto.from(accessToken, refreshToken);
+        return LoginResponseDto.from(
+                jwtTokenProvider.createAccessToken(user.getId()),
+                refreshToken);
     }
 }

--- a/src/main/java/com/backend/doyouhave/service/UserService.java
+++ b/src/main/java/com/backend/doyouhave/service/UserService.java
@@ -25,14 +25,12 @@ public class UserService {
     public LoginResponseDto signup(Role role, String code) {
 
         if (role.equals(Role.KAKAO)) {
-            String accessToken = authService.getAccessTokenByCode(code);
-            Optional<User> kakaoUser = authService.saveUserInfoByToken(accessToken);
+            String accessToken = authService.getKakaoAccessTokenByCode(code);
+            Optional<User> kakaoUser = authService.saveUserInfoByKakaoToken(accessToken);
             Optional<User> existUser = userRepository.findByRoleAndSocialId(Role.KAKAO, kakaoUser.get().getSocialId());
             if(!existUser.isEmpty()){
-                // exist
                 return login(existUser.get());
             }
-            // signup
             userRepository.save(kakaoUser.get());
             return login(kakaoUser.get());
 
@@ -45,9 +43,8 @@ public class UserService {
     }
 
     public LoginResponseDto login(User user) {
-        // JWT 구현 예정
-
-        String refreshToken = "refreshToken";
+        String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+        authService.updateRefreshToken(user.getId(), refreshToken);
 
         return LoginResponseDto.from(
                 jwtTokenProvider.createAccessToken(user.getId()),


### PR DESCRIPTION
사용자 인증을 위해 JWT 기능을 구현했습니다.
### 로그인 시
`{ "accessToken":"~", "refreshToken":"~"}`
JSON 클라이언트로 반환

### 인증이 필요한 API 경우
요청 헤더(Bearer Token)에 accessToken을 담아 전송

> **토큰 오류 시 응답**
> 401 : accessToken 에러 (message에 이유 기재하였습니다. ex. "TOKEN EXPIRED", "FAIL AUTHENTICATION")
> 403 : 권한 에러 (admin 전용 API를 일반 회원이 요청한 경우)

### accessToken 리프레시
401 "TOKEN EXPIRED" 에러인 경우 클라이언트는 토큰 리프레시 API로 요청.
body에 `{"refreshToken":"~"}`으로 요청.

`{ "accessToken":"~", "refreshToken":"~"}`
JSON 클라이언트로 반환

> **토큰 오류 시 응답**
> 401 : refreshToken 에러 (이 경우 재로그인이 필요.)