### PR TITLE
feat: 알림 조회 API 추가 및 카테고리 설계

### DIFF
--- a/src/main/java/com/backend/doyouhave/controller/PostController.java
+++ b/src/main/java/com/backend/doyouhave/controller/PostController.java
@@ -1,14 +1,17 @@
 package com.backend.doyouhave.controller;
 
+import com.backend.doyouhave.domain.notification.dto.NotificationResponseDto;
 import com.backend.doyouhave.domain.post.Post;
 import com.backend.doyouhave.domain.post.dto.PostRequestDto;
 import com.backend.doyouhave.domain.post.dto.PostResponseDto;
 import com.backend.doyouhave.domain.user.User;
 import com.backend.doyouhave.repository.user.UserRepository;
 import com.backend.doyouhave.service.PostService;
+import com.backend.doyouhave.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -23,7 +26,7 @@ import java.util.Optional;
 @RestController
 public class PostController {
     private final PostService postService;
-    private final UserRepository userRepository;
+    private final UserService userService;
     /* 전단지 작성 API */
     @PostMapping("/posts")
     public ResponseEntity<PostResponseDto> savePost(
@@ -46,11 +49,12 @@ public class PostController {
         return ResponseEntity.created(uri).body(response);
     }
 
-    /* 최근 알림 API
+    /* 최근 알림 API */
     @GetMapping("/mypage/notifications")
-    public ResponseEntity<UserRequestDto> getNotification(
-            @PathVariable Long userId,
-            @RequestBody UserRequestDto userRequestDto) {
-        Optional<User> user = userRepository.findById(userId);
-    } */
+    public ResponseEntity<List<NotificationResponseDto>> getNotification(@PathVariable Long userId) {
+
+        // 댓글 생성시 글 작성자의 알림에 추가하는 로직이 필요
+        List<NotificationResponseDto> notificationResponseDtos = userService.getNotifications(userId);
+        return ResponseEntity.status(200).body(notificationResponseDtos);
+    }
 }

--- a/src/main/java/com/backend/doyouhave/domain/notification/Notification.java
+++ b/src/main/java/com/backend/doyouhave/domain/notification/Notification.java
@@ -1,27 +1,38 @@
 package com.backend.doyouhave.domain.notification;
 
+import com.backend.doyouhave.domain.user.User;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-import javax.persistence.Embeddable;
+import javax.persistence.*;
 import java.time.LocalDateTime;
 
-@Embeddable
 @Getter
-public class Notification {
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Notification{
+    @Id @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
 
-    private String post_title;
+    @Column(nullable = false)
+    private String postTitle;
 
-    private String comment_content;
+    @Column(nullable = false)
+    private String commentContent;
 
+    @Column(nullable = false)
     private LocalDateTime notifiedDate;
 
-    protected Notification() {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 
-    }
-
-    public void create(String post_title, String comment_content) {
-        this.post_title = post_title;
-        this.comment_content = comment_content;
+    public void create(String postTitle, String commentContent) {
+        this.postTitle = postTitle;
+        this.commentContent = commentContent;
         this.notifiedDate = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/backend/doyouhave/domain/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/notification/dto/NotificationResponseDto.java
@@ -1,0 +1,22 @@
+package com.backend.doyouhave.domain.notification.dto;
+
+import com.backend.doyouhave.domain.notification.Notification;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Getter
+public class NotificationResponseDto {
+    private Long notificationId;
+    private String postTitle;
+    private String commentContent;
+    private String notifiedDate;
+
+    public NotificationResponseDto(Notification notification) {
+        this.notificationId = notification.getId();
+        this.postTitle = notification.getPostTitle();
+        this.commentContent = notification.getCommentContent();
+        this.notifiedDate = notification.getNotifiedDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+    }
+}

--- a/src/main/java/com/backend/doyouhave/domain/post/Category.java
+++ b/src/main/java/com/backend/doyouhave/domain/post/Category.java
@@ -1,0 +1,37 @@
+package com.backend.doyouhave.domain.post;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Category {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    @Column(name = "category_id")
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String keyword;
+
+    @Column(nullable = false)
+    private int count;
+
+    @ElementCollection
+    private List<String> tags = new ArrayList<>();
+
+    @Builder
+    public Category(String keyword, int count, List<String> tags) {
+        this.keyword = keyword;
+        this.count = count;
+        this.tags = tags;
+    }
+}

--- a/src/main/java/com/backend/doyouhave/domain/post/Post.java
+++ b/src/main/java/com/backend/doyouhave/domain/post/Post.java
@@ -2,6 +2,7 @@ package com.backend.doyouhave.domain.post;
 
 import com.backend.doyouhave.domain.BaseTimeEntity;
 import com.backend.doyouhave.domain.comment.Comment;
+import com.backend.doyouhave.domain.user.User;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
@@ -9,6 +10,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 @Embeddable
@@ -33,18 +35,21 @@ public class Post extends BaseTimeEntity {
     @Column(nullable = false)
     private String category;
 
-    @ElementCollection
-    private List<String> tags = new ArrayList<>();
+    private String tags;
 
     @Column(nullable = false)
     private String img;
 
     private String imgSecond;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<Comment> commentList = new ArrayList<>();
 
-    public void create(String title, String content, String contactWay, String category, List<String> tags, String img, String imgSecond) {
+    public void create(String title, String content, String contactWay, String category, String tags, String img, String imgSecond) {
         this.title = title;
         this.content = content;
         this.contactWay = contactWay;
@@ -52,5 +57,10 @@ public class Post extends BaseTimeEntity {
         this.tags = tags;
         this.img = img;
         this.imgSecond = imgSecond;
+    }
+
+    public void setUser(User user) {
+        user.getPosts().add(this);
+        this.user = user;
     }
  }

--- a/src/main/java/com/backend/doyouhave/domain/post/dto/PostRequestDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/post/dto/PostRequestDto.java
@@ -24,7 +24,7 @@ public class PostRequestDto {
     @NotNull
     private String categoryKeyword;
 
-    private List<String> tags = new ArrayList<>();
+    private String tags;
 
     @NotNull
     private String img;
@@ -32,7 +32,7 @@ public class PostRequestDto {
     private String imgSecond;
 
     @Builder
-    public PostRequestDto(String title, String content, String contactWay, String categoryKeyword, List<String> tags,String img, String imgSecond) {
+    public PostRequestDto(String title, String content, String contactWay, String categoryKeyword, String tags,String img, String imgSecond) {
         this.title = title;
         this.content = content;
         this.contactWay = contactWay;

--- a/src/main/java/com/backend/doyouhave/domain/user/User.java
+++ b/src/main/java/com/backend/doyouhave/domain/user/User.java
@@ -2,6 +2,8 @@ package com.backend.doyouhave.domain.user;
 
 import com.backend.doyouhave.domain.BaseTimeEntity;
 import com.backend.doyouhave.domain.comment.Comment;
+import com.backend.doyouhave.domain.notification.Notification;
+import com.backend.doyouhave.domain.post.Post;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -50,6 +52,15 @@ public class User extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Post> posts = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Notification> notifications = new ArrayList<>();
+    public void setNotification(Notification notification) {
+        this.notifications.add(notification);
+    }
 
     public static User createKakaoUser(Long kakaoId, String email, String img, String nickname) {
         return User.builder()

--- a/src/main/java/com/backend/doyouhave/repository/notification/NotificationRepository.java
+++ b/src/main/java/com/backend/doyouhave/repository/notification/NotificationRepository.java
@@ -1,0 +1,10 @@
+package com.backend.doyouhave.repository.notification;
+
+import com.backend.doyouhave.domain.notification.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findTop8ByUserIdOrderByNotifiedDateDesc(Long userId);
+}

--- a/src/main/java/com/backend/doyouhave/repository/post/CategoryRepository.java
+++ b/src/main/java/com/backend/doyouhave/repository/post/CategoryRepository.java
@@ -1,0 +1,8 @@
+package com.backend.doyouhave.repository.post;
+
+import com.backend.doyouhave.domain.post.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+    Category findByKeyword(String keyword);
+}

--- a/src/main/java/com/backend/doyouhave/service/PostService.java
+++ b/src/main/java/com/backend/doyouhave/service/PostService.java
@@ -1,6 +1,8 @@
 package com.backend.doyouhave.service;
 
+import com.backend.doyouhave.domain.post.Category;
 import com.backend.doyouhave.domain.post.Post;
+import com.backend.doyouhave.repository.post.CategoryRepository;
 import com.backend.doyouhave.repository.post.PostRepository;
 import com.backend.doyouhave.util.CloudManager;
 import com.cloudinary.utils.ObjectUtils;
@@ -11,6 +13,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -21,12 +24,33 @@ import java.util.stream.Collectors;
 public class PostService {
 
     private final PostRepository postRepository;
+    private final CategoryRepository categoryRepository;
     private final CloudManager cloudManager;
 
     /* 전단지 작성 */
     public Long savePost(Post savedPost, MultipartFile imageFile, MultipartFile imageFileSecond) throws IOException {
-        // User user = findUser(userId); post.setUser(user); 토큰으로 가져오는 경우 authToken 사용
 
+        // savedPost.setUser(user);
+        // 카테고리 별로 태그 저장. 카테고리가 기존에 존재하는 키워드라면 해당 카테고리에 속하는 태그들을 추가하는 방식
+        Category categoryResult = categoryRepository.findByKeyword(savedPost.getCategory());
+        if(categoryResult == null) {
+            List<String> tagList =  Arrays.stream(savedPost.getTags().split(",")).toList();
+            categoryResult = Category.builder()
+                    .keyword(savedPost.getCategory())
+                    .count(0)
+                    .tags(tagList)
+                    .build();
+        } else {
+            List<String> tags = categoryResult.getTags();
+            List<String> postTags =  Arrays.stream(savedPost.getTags().split(",")).toList();
+            for(String tag : postTags) {
+                tags.add(tag);
+            }
+        }
+        categoryResult.setCount(categoryResult.getCount() + 1);
+        categoryRepository.save(categoryResult);
+
+        // 클라우디너리에 이미지 저장 및 글 작성 처리
         postRepository.save(savedPost);
         Map<Object, Map> uploadResultFirst = cloudManager.uploadFile(savedPost.getId(), imageFile);
         if(uploadResultFirst!=null) {
@@ -45,4 +69,5 @@ public class PostService {
 //        return userRepository.findById(id)
 //                .orElseThrow(() -> new NoSuchElementException("해당 유저가 존재하지 않습니다."));
 //    }
+
 }

--- a/src/main/java/com/backend/doyouhave/service/UserService.java
+++ b/src/main/java/com/backend/doyouhave/service/UserService.java
@@ -1,27 +1,34 @@
 package com.backend.doyouhave.service;
 
 import com.backend.doyouhave.domain.comment.dto.CommentRequestDto;
+import com.backend.doyouhave.domain.notification.Notification;
+import com.backend.doyouhave.domain.notification.dto.NotificationResponseDto;
 import com.backend.doyouhave.domain.user.Role;
 import com.backend.doyouhave.domain.user.User;
 import com.backend.doyouhave.domain.user.dto.LoginResponseDto;
 import com.backend.doyouhave.domain.user.dto.UserProfileResponseDto;
 import com.backend.doyouhave.exception.NotFoundException;
 import com.backend.doyouhave.jwt.JwtTokenProvider;
+import com.backend.doyouhave.repository.notification.NotificationRepository;
 import com.backend.doyouhave.repository.post.PostRepository;
 import com.backend.doyouhave.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Transactional
 @RequiredArgsConstructor
 @Service
 public class UserService {
     private final UserRepository userRepository;
+    private final NotificationRepository notificationRepository;
     private final AuthService authService;
     private final JwtTokenProvider jwtTokenProvider;
+
     public LoginResponseDto signup(Role role, String code) {
 
         if (role.equals(Role.KAKAO)) {
@@ -54,5 +61,20 @@ public class UserService {
     public UserProfileResponseDto findUsersProfile(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(() -> new NotFoundException());
         return UserProfileResponseDto.from(user);
+    }
+
+
+    // 최근 알림 중 최대 8개만 뽑아서 반환
+    public List<NotificationResponseDto> getNotifications(Long userId) {
+        List<NotificationResponseDto> notificationResponseDtos = notificationRepository
+                .findTop8ByUserIdOrderByNotifiedDateDesc(userId)
+                .stream()
+                .map(NotificationResponseDto::new)
+                .collect(Collectors.toList());
+        if(notificationResponseDtos.isEmpty()) {
+            return null;
+        } else {
+            return notificationResponseDtos;
+        }
     }
 }


### PR DESCRIPTION

- User의 최근 알림 조회 API 추가 (UserService에 비즈니스 로직이 속해있으니 참고하시면 될 것 같습니다.)
- 댓글 생성 시 해당 글 작성자에 묶여있는 List<Notification>에 알림을 추가하는 로직이 필요해 보였습니다.

- 카테고리의 경우 Post에는 문자열만 받고 Category 엔티티를 독립적으로 생성해 태그들이 추가되는 방식입니다.