### PR TITLE
Feat: Naver Login API 구현

### DIFF
--- a/src/main/java/com/backend/doyouhave/config/SecurityConfig.java
+++ b/src/main/java/com/backend/doyouhave/config/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig {
                 "/v3/api-docs/**",
                 "/swagger-ui/**",
                 "/api/users/kakao-login",
+                "/api/users/naver-login",
                 "/api/auth/token-refresh"
         );
     }

--- a/src/main/java/com/backend/doyouhave/controller/AuthController.java
+++ b/src/main/java/com/backend/doyouhave/controller/AuthController.java
@@ -1,11 +1,8 @@
 package com.backend.doyouhave.controller;
 
-import com.backend.doyouhave.domain.user.Role;
-import com.backend.doyouhave.domain.user.dto.LoginRequestDto;
 import com.backend.doyouhave.domain.user.dto.LoginResponseDto;
 import com.backend.doyouhave.domain.user.dto.TokenRefreshRequestDto;
 import com.backend.doyouhave.service.AuthService;
-import com.backend.doyouhave.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/src/main/java/com/backend/doyouhave/controller/UserController.java
+++ b/src/main/java/com/backend/doyouhave/controller/UserController.java
@@ -1,8 +1,9 @@
 package com.backend.doyouhave.controller;
 
 import com.backend.doyouhave.domain.user.Role;
-import com.backend.doyouhave.domain.user.dto.LoginRequestDto;
+import com.backend.doyouhave.domain.user.dto.KakaoLoginRequestDto;
 import com.backend.doyouhave.domain.user.dto.LoginResponseDto;
+import com.backend.doyouhave.domain.user.dto.NaverLoginRequestDto;
 import com.backend.doyouhave.domain.user.dto.UserProfileResponseDto;
 import com.backend.doyouhave.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -18,8 +19,14 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/kakao-login")
-    public LoginResponseDto loginUser(@RequestBody @Valid LoginRequestDto request) {
-        return userService.signup(Role.KAKAO, request.getCode());
+    public LoginResponseDto kakaoLoginUser(@RequestBody @Valid KakaoLoginRequestDto request) {
+        return userService.signup(Role.KAKAO, request.getCode(), null);
+
+    }
+
+    @PostMapping("/naver-login")
+    public LoginResponseDto naverLoginUser(@RequestBody @Valid NaverLoginRequestDto request) {
+        return userService.signup(Role.NAVER, request.getCode(), request.getState());
 
     }
 

--- a/src/main/java/com/backend/doyouhave/domain/user/User.java
+++ b/src/main/java/com/backend/doyouhave/domain/user/User.java
@@ -34,7 +34,7 @@ public class User extends BaseTimeEntity {
     private Long id;
 
     @Column(name = "social_id", nullable = false)
-    private Long socialId;
+    private String socialId;
 
     private String email;
 
@@ -62,7 +62,7 @@ public class User extends BaseTimeEntity {
         this.notifications.add(notification);
     }
 
-    public static User createKakaoUser(Long kakaoId, String email, String img, String nickname) {
+    public static User createKakaoUser(String kakaoId, String email, String img, String nickname) {
         return User.builder()
                 .socialId(kakaoId)
                 .email(email)
@@ -72,7 +72,7 @@ public class User extends BaseTimeEntity {
                 .build();
     }
 
-    public static User createNaverUser(Long naverId, String email, String img, String nickname) {
+    public static User createNaverUser(String naverId, String email, String img, String nickname) {
         return User.builder()
                 .socialId(naverId)
                 .email(email)

--- a/src/main/java/com/backend/doyouhave/domain/user/dto/KakaoLoginRequestDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/user/dto/KakaoLoginRequestDto.java
@@ -8,7 +8,7 @@ import javax.validation.constraints.NotBlank;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class LoginRequestDto {
+public class KakaoLoginRequestDto {
     @NotBlank
     private String code;
 }

--- a/src/main/java/com/backend/doyouhave/domain/user/dto/NaverLoginRequestDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/user/dto/NaverLoginRequestDto.java
@@ -1,0 +1,17 @@
+package com.backend.doyouhave.domain.user.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class NaverLoginRequestDto {
+    @NotBlank
+    private String code;
+
+    @NotBlank
+    private String state;
+}

--- a/src/main/java/com/backend/doyouhave/repository/user/UserRepository.java
+++ b/src/main/java/com/backend/doyouhave/repository/user/UserRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByRoleAndSocialId(Role role, Long socialId);
+    Optional<User> findByRoleAndSocialId(Role role, String socialId);
 
     @Query(value = "SELECT u.refresh_token FROM Users u WHERE u.user_id = :id", nativeQuery = true)
     String findRefreshTokenById(@Param("id") Long userId);

--- a/src/main/java/com/backend/doyouhave/service/AuthService.java
+++ b/src/main/java/com/backend/doyouhave/service/AuthService.java
@@ -38,6 +38,16 @@ public class AuthService {
     @Value("${auth.kakao.redirecturl}")
     private String authKakaoRedirectUrl;
 
+    @Value("${auth.naver.clientId}")
+    private String authNaverClientId;
+
+    @Value("${auth.naver.key}")
+    private String authNaverKey;
+
+    @Value("${auth.naver.redirecturl}")
+    private String authNaverRedirectUrl;
+
+
     public String getKakaoAccessTokenByCode(String code) {
         String accessToken = "";
         try{
@@ -91,13 +101,79 @@ public class AuthService {
 
             JSONParser parser = new JSONParser();
             JSONObject elem = (JSONObject) parser.parse(response.getBody());
-            System.out.println("elem = " + elem);
+
             Long id = (Long) elem.get("id");
             String email = (String) ((JSONObject) elem.get("kakao_account")).get("email");
             String nickname = (String) ((JSONObject) elem.get("properties")).get("nickname");
             String img = (String) ((JSONObject) elem.get("properties")).get("profile_image");
 
             return Optional.ofNullable(User.createKakaoUser(id, email, img, nickname));
+        } catch (Exception e) {
+            throw new SocialLoginException();
+        }
+    }
+
+    public String getNaverAccessTokenByCode(String code, String state) {
+        String accessToken = "";
+        try{
+            HttpHeaders headers = new HttpHeaders();
+            headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+            MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+            params.add("grant_type", "authorization_code");
+            params.add("client_id", authNaverClientId);
+            params.add("client_secret", authNaverKey);
+            params.add("code", code);
+            params.add("state", state);
+
+            RestTemplate rt = new RestTemplate();
+            rt.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+            HttpEntity<MultiValueMap<String, String>> naverTokenRequest =
+                    new HttpEntity<>(params, headers);
+
+            ResponseEntity<String> response = rt.exchange(
+                    "https://nid.naver.com/oauth2.0/token",
+                    HttpMethod.POST,
+                    naverTokenRequest,
+                    String.class
+            );
+
+            JSONParser parser = new JSONParser();
+            JSONObject elem = (JSONObject) parser.parse(response.getBody());
+            System.out.println("elem = " + elem);
+            accessToken = (String) elem.get("access_token");
+        } catch (Exception e) {
+            throw new SocialLoginException();
+        }
+        return accessToken;
+    }
+
+    public Optional<User> saveUserInfoByNaverToken(String accessToken) {
+        try{
+            HttpHeaders headers = new HttpHeaders();
+            headers.add("Authorization", "Bearer " + accessToken);
+            headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+            RestTemplate rt = new RestTemplate();
+            rt.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+
+            HttpEntity<MultiValueMap<String, String>> naverProfileRequest = new HttpEntity<>(headers);
+
+            ResponseEntity<String> response = rt.exchange(
+                    "https://openapi.naver.com/v1/nid/me",
+                    HttpMethod.GET,
+                    naverProfileRequest,
+                    String.class
+            );
+
+            JSONParser parser = new JSONParser();
+            JSONObject elem = (JSONObject) ((JSONObject) parser.parse(response.getBody())).get("response");
+            System.out.println("elem = " + elem);
+            Long id = (Long) elem.get("id");
+            String email = (String) elem.get("email");
+            String nickname = (String) elem.get("name");
+            String img = (String) elem.get("profile_image");
+
+            return Optional.ofNullable(User.createNaverUser(id, email, img, nickname));
         } catch (Exception e) {
             throw new SocialLoginException();
         }

--- a/src/main/java/com/backend/doyouhave/service/AuthService.java
+++ b/src/main/java/com/backend/doyouhave/service/AuthService.java
@@ -102,7 +102,7 @@ public class AuthService {
             JSONParser parser = new JSONParser();
             JSONObject elem = (JSONObject) parser.parse(response.getBody());
 
-            Long id = (Long) elem.get("id");
+            String id = String.valueOf((Long) elem.get("id"));
             String email = (String) ((JSONObject) elem.get("kakao_account")).get("email");
             String nickname = (String) ((JSONObject) elem.get("properties")).get("nickname");
             String img = (String) ((JSONObject) elem.get("properties")).get("profile_image");
@@ -168,7 +168,7 @@ public class AuthService {
             JSONParser parser = new JSONParser();
             JSONObject elem = (JSONObject) ((JSONObject) parser.parse(response.getBody())).get("response");
             System.out.println("elem = " + elem);
-            Long id = (Long) elem.get("id");
+            String id = (String) elem.get("id");
             String email = (String) elem.get("email");
             String nickname = (String) elem.get("name");
             String img = (String) elem.get("profile_image");


### PR DESCRIPTION
**네이버 소셜 로그인 API** 구현했습니다.
#### 이슈
네이버에서 제공하는 소셜 ID가 String 형태라 기존 User의 socialId(Long)와 타입 불일치 이슈가 있었습니다.
-> **User Entity의 socialId 타입을 String으로 변경**

> 카카오 소셜 ID는 형변환을 통해 String으로 바꿔 저장하는 식으로 수정했습니다.

(Env 파일 수정이 있어서 노션 확인 부탁드립니다.)