### PR TITLE
feat: 전단지 수정 API 추가 및 리팩토링

### DIFF
--- a/src/main/java/com/backend/doyouhave/controller/PostController.java
+++ b/src/main/java/com/backend/doyouhave/controller/PostController.java
@@ -4,9 +4,12 @@ import com.backend.doyouhave.domain.notification.dto.NotificationResponseDto;
 import com.backend.doyouhave.domain.post.Post;
 import com.backend.doyouhave.domain.post.dto.PostRequestDto;
 import com.backend.doyouhave.domain.post.dto.PostResponseDto;
+import com.backend.doyouhave.domain.post.dto.PostUpdateRequestDto;
+import com.backend.doyouhave.domain.post.dto.PostUpdateResponseDto;
 import com.backend.doyouhave.domain.user.User;
 import com.backend.doyouhave.exception.ExceptionCode;
 import com.backend.doyouhave.exception.ExceptionResponse;
+import com.backend.doyouhave.exception.NotFoundException;
 import com.backend.doyouhave.repository.user.UserRepository;
 import com.backend.doyouhave.service.PostService;
 import com.backend.doyouhave.service.UserService;
@@ -22,6 +25,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 import java.net.URI;
@@ -42,7 +46,7 @@ public class PostController {
             @PathVariable Long userId,
 //            @AuthenticationPrincipal User user,
             @RequestPart(value="dto") PostRequestDto postRequestDto,
-            @RequestPart(value="img") MultipartFile imageFile,
+            @RequestPart(value="img", required = false) MultipartFile imageFile,
             @RequestPart(value="imgSecond", required = false) MultipartFile imageFileSecond) throws IOException {
 
         Post post = postRequestDto.toEntity();
@@ -55,6 +59,37 @@ public class PostController {
                 .toUri();
 
         return ResponseEntity.created(uri).body(responseService.getSingleResult(new PostResponseDto(savedPostId)));
+    }
+
+    /* 전단지 수정 API - 수정 페이지 (기존 등록된 전단지의 정보 반환) */
+    @GetMapping("/posts/{postId}/edit")
+    public ResponseEntity<?> updatePostInfo(
+            @PathVariable Long userId,
+            @PathVariable Long postId) {
+        PostUpdateResponseDto updateResponse = postService.getPostInfo(postId);
+        if(updateResponse == null) {
+            return ResponseEntity.ok(ExceptionResponse.of(ExceptionCode.NOT_FOUND, "전단지가 존재하지 않습니다."));
+        }
+        return ResponseEntity.ok(responseService.getSingleResult(updateResponse));
+    }
+
+    /* 전단지 수정 API - 수정 처리 */
+    @PostMapping("/posts/{postId}/edit")
+    public ResponseEntity<Result> updatePost(
+            @PathVariable Long userId,
+            @PathVariable Long postId,
+            @RequestPart(value="updatePost") PostUpdateRequestDto postUpdateRequestDto,
+            @RequestPart(value="img") MultipartFile updateImage,
+            @RequestPart(value="imgSecond") MultipartFile updateImageSecond) throws IOException {
+        // 수정된 정보들을 받아 수정 처리
+        Post updatedPost = postService.updatePost(postId, postUpdateRequestDto, updateImage, updateImageSecond);
+
+        URI uri = UriComponentsBuilder.fromUriString("http://localhost:8080")
+                .path("/api/users/{userId}/post/{postId}")
+                .buildAndExpand(userId, postId)
+                .toUri();
+
+        return ResponseEntity.created(uri).body(responseService.getSingleResult(updatedPost.getId()));
     }
 
     /* 전단지 삭제 API */

--- a/src/main/java/com/backend/doyouhave/domain/post/Post.java
+++ b/src/main/java/com/backend/doyouhave/domain/post/Post.java
@@ -2,6 +2,7 @@ package com.backend.doyouhave.domain.post;
 
 import com.backend.doyouhave.domain.BaseTimeEntity;
 import com.backend.doyouhave.domain.comment.Comment;
+import com.backend.doyouhave.domain.post.dto.PostUpdateRequestDto;
 import com.backend.doyouhave.domain.user.User;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -37,7 +38,6 @@ public class Post extends BaseTimeEntity {
 
     private String tags;
 
-    @Column(nullable = false)
     private String img;
 
     private String imgSecond;
@@ -49,14 +49,20 @@ public class Post extends BaseTimeEntity {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<Comment> commentList = new ArrayList<>();
 
-    public void create(String title, String content, String contactWay, String category, String tags, String img, String imgSecond) {
+    public void create(String title, String content, String contactWay, String category, String tags) {
         this.title = title;
         this.content = content;
         this.contactWay = contactWay;
         this.category = category;
         this.tags = tags;
-        this.img = img;
-        this.imgSecond = imgSecond;
+    }
+
+    public void update(PostUpdateRequestDto entity) {
+        this.title = entity.getTitle();
+        this.content = entity.getContent();
+        this.contactWay = entity.getContactWay();
+        this.category = entity.getCategoryKeyword();
+        this.tags = entity.getTags();
     }
 
     public void setUser(User user) {

--- a/src/main/java/com/backend/doyouhave/domain/post/dto/PostRequestDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/post/dto/PostRequestDto.java
@@ -26,25 +26,19 @@ public class PostRequestDto {
 
     private String tags;
 
-    @NotNull
-    private String img;
-
-    private String imgSecond;
 
     @Builder
-    public PostRequestDto(String title, String content, String contactWay, String categoryKeyword, String tags,String img, String imgSecond) {
+    public PostRequestDto(String title, String content, String contactWay, String categoryKeyword, String tags) {
         this.title = title;
         this.content = content;
         this.contactWay = contactWay;
         this.categoryKeyword = categoryKeyword;
         this.tags = tags;
-        this.img = img;
-        this.imgSecond = imgSecond;
     }
 
     public Post toEntity() {
         Post post = new Post();
-        post.create(title, content, contactWay, categoryKeyword, tags, img, imgSecond);
+        post.create(title, content, contactWay, categoryKeyword, tags);
         return post;
     }
 }

--- a/src/main/java/com/backend/doyouhave/domain/post/dto/PostUpdateRequestDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/post/dto/PostUpdateRequestDto.java
@@ -1,0 +1,22 @@
+package com.backend.doyouhave.domain.post.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor
+public class PostUpdateRequestDto {
+
+    @NotNull
+    private String title;
+    @NotNull
+    private String content;
+    @NotNull
+    private String contactWay;
+    @NotNull
+    private String categoryKeyword;
+
+    private String tags;
+}

--- a/src/main/java/com/backend/doyouhave/domain/post/dto/PostUpdateResponseDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/post/dto/PostUpdateResponseDto.java
@@ -1,0 +1,41 @@
+package com.backend.doyouhave.domain.post.dto;
+
+import com.backend.doyouhave.domain.post.Post;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+import java.util.Arrays;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class PostUpdateResponseDto {
+
+    private String title;
+
+    private String content;
+
+    private String contactWay;
+
+    private String categoryKeyword;
+
+    private List<String> tags;
+
+    private String img;
+
+    private String imgSecond;
+
+    @Builder
+    public PostUpdateResponseDto(Post entity) {
+        this.title = entity.getTitle();
+        this.content = entity.getContent();
+        this.contactWay = entity.getContactWay();
+        this.categoryKeyword = entity.getCategory();
+        List<String> entityTags = Arrays.stream(entity.getTags().split(",")).toList();
+        this.tags = entityTags;
+        this.img = entity.getImg();
+        this.imgSecond = entity.getImgSecond();
+    }
+}

--- a/src/main/java/com/backend/doyouhave/util/CloudManager.java
+++ b/src/main/java/com/backend/doyouhave/util/CloudManager.java
@@ -41,9 +41,10 @@ public class CloudManager {
     public void uploadFile(Long postId, MultipartFile uploadFile, MultipartFile uploadFileSecond, Post savedPost) throws IOException {
         String folderName = String.valueOf(postId);
         try {
-            // 첫번째 사진은 필수, 두번째 사진은 선택
-            String newFileName = getFileUrlByUpload(folderName, uploadFile);
-            savedPost.setImg("http://res.cloudinary.com/do-you-have/image/upload/Post_"+folderName+"/"+newFileName+".jpg");
+            if(uploadFile != null) {
+                String newFileName = getFileUrlByUpload(folderName, uploadFile);
+                savedPost.setImg("http://res.cloudinary.com/do-you-have/image/upload/Post_"+folderName+"/"+newFileName+".jpg");
+            }
 
             if(uploadFileSecond != null) {
                 String newFileNameSecond = getFileUrlByUpload(folderName, uploadFileSecond);
@@ -67,15 +68,19 @@ public class CloudManager {
 
     public void deleteFile(Post foundedPost, String uploadedFile, String uploadedFileSecond) throws IOException {
         String folderName = String.valueOf(foundedPost.getId());
-        String fileName = uploadedFile.substring(uploadedFile.lastIndexOf("/"), uploadedFile.length());
-        System.out.println(fileName);
-        Map options = ObjectUtils.asMap("type", "upload");
-        cloudinary.uploader().destroy("Post_"+folderName+fileName, options);
+        if(uploadedFile!=null) {
+            String fileName = uploadedFile.substring(uploadedFile.lastIndexOf("/"), uploadedFile.length()-4);
+            System.out.println(fileName);
+            Map options = ObjectUtils.asMap("type", "upload");
+            options.put("invalidate", true);
+            cloudinary.uploader().destroy("Post_"+folderName+fileName, options);
+        }
 
         if(uploadedFileSecond!=null) {
-            String fileNameSecond = uploadedFileSecond.substring(uploadedFileSecond.lastIndexOf("/"), uploadedFileSecond.length());
+            String fileNameSecond = uploadedFileSecond.substring(uploadedFileSecond.lastIndexOf("/"), uploadedFileSecond.length()-4);
             System.out.println(fileNameSecond);
             Map optionsSecond = ObjectUtils.asMap("type", "upload");
+            optionsSecond.put("invalidate", true);
             cloudinary.uploader().destroy("Post_"+folderName+fileNameSecond, optionsSecond);
         }
     }


### PR DESCRIPTION
 - 클라우디너리 파일 업로드 후 이미지 파일 삭제 처리가 안되는 문제가 발생해 기존 로직을 수정하였습니다.
 - 이미지 경로를 정상적으로 DB에 저장하기 위해 Post 비즈니스 로직을 수정하였습니다.
 - 이미지는 최대 2개 업로드가 가능하며 필수가 아닌 선택으로 글을 작성할 수 있도록 이미지 필드의 @NotNull 을 제거하였습니다.
 
- 전단지 수정 API 추가