### PR TITLE
feat: 카테고리, 태그 및 정렬별 전단지 목록 조회 API, 인기 태그 API 추가

### DIFF
--- a/src/main/java/com/backend/doyouhave/controller/MainController.java
+++ b/src/main/java/com/backend/doyouhave/controller/MainController.java
@@ -1,15 +1,26 @@
 package com.backend.doyouhave.controller;
 
 import com.backend.doyouhave.domain.main.MainInfoDto;
+import com.backend.doyouhave.domain.post.Post;
+import com.backend.doyouhave.domain.post.dto.PostListResponseDto;
+import com.backend.doyouhave.service.PostFilterService;
 import com.backend.doyouhave.service.PostService;
+import com.backend.doyouhave.service.result.MultiplePageResult;
+import com.backend.doyouhave.service.result.MultipleResult;
 import com.backend.doyouhave.service.result.ResponseService;
 import com.backend.doyouhave.service.result.SingleResult;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -18,6 +29,7 @@ import java.util.Map;
 public class MainController {
 
     private final PostService postService;
+    private final PostFilterService postFilterService;
     private final ResponseService responseService;
 
     @GetMapping
@@ -26,5 +38,33 @@ public class MainController {
         Map<String, Integer> countPost = postService.findCountPost();
 
         return ResponseEntity.ok(responseService.getSingleResult(new MainInfoDto(countPost.get("allCount"), countPost.get("todayCount"))));
+    }
+
+    /* 전단지 조회 API */
+    @GetMapping("/list")
+    @ApiOperation(value = "전단지 리스트", notes = "선택한 카테고리 및 정렬순에 따라 전단지를 보여준다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "성공"),
+            @ApiResponse(code = 401, message = "권한이 없는 사용자입니다."),
+            @ApiResponse(code = 404, message = "잘못된 요청입니다.")
+    })
+    public ResponseEntity<MultiplePageResult> postListUp(
+            @PathVariable Long userId,
+            @RequestParam(name="category", required = false) String category,
+            @RequestParam(name="tag", required = false) String tag,
+            @RequestParam(name="sort", required = false) String sort,
+            @PageableDefault(size=20) Pageable pageable) {
+
+        Page<PostListResponseDto> response = postFilterService.findPostByCategoryOrTags(category, tag, sort, pageable);
+        return ResponseEntity.ok(responseService.getMultiplePageResult(response));
+    }
+
+    /* 인기 태그 조회 API */
+    @GetMapping("/list/top")
+    public ResponseEntity<MultipleResult> postTop5Tag(
+            @PathVariable Long userId,
+            @RequestParam(name="category", required = false) String category) {
+        List<String> topTags = postService.findTopTags(category);
+        return ResponseEntity.ok(responseService.getMultipleResult(topTags));
     }
 }

--- a/src/main/java/com/backend/doyouhave/domain/comment/Comment.java
+++ b/src/main/java/com/backend/doyouhave/domain/comment/Comment.java
@@ -68,9 +68,17 @@ public class Comment extends BaseTimeEntity {
 
     public void delete() {
         this.isRemoved = true;
+        this.getPost().getCommentList().remove(this);
+        this.getPost().setCommentNum(this.getPost().getCommentList().size() - 1);
     }
 
     public void conversion() {
         this.isSecret = true;
+    }
+
+    public void setPost(Post post) {
+        post.getCommentList().add(this);
+        post.setCommentNum(post.getCommentList().size() + 1);
+        this.post = post;
     }
 }

--- a/src/main/java/com/backend/doyouhave/domain/comment/dto/CommentRequestDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/comment/dto/CommentRequestDto.java
@@ -35,6 +35,7 @@ public class CommentRequestDto {
 
     public Comment toEntityParent() {
         Comment comment = new Comment();
+        comment.setPost(post);
         comment.createParent(user, post, content, isSecret);
 
         return comment;
@@ -42,6 +43,7 @@ public class CommentRequestDto {
 
     public Comment toEntityChild() {
         Comment comment = new Comment();
+        comment.setPost(post);
         comment.createChild(user, post, content, parent.toEntityParent(), isSecret);
 
         return comment;

--- a/src/main/java/com/backend/doyouhave/domain/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/notification/dto/NotificationResponseDto.java
@@ -1,6 +1,7 @@
 package com.backend.doyouhave.domain.notification.dto;
 
 import com.backend.doyouhave.domain.notification.Notification;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -8,9 +9,13 @@ import java.time.format.DateTimeFormatter;
 
 @Getter
 public class NotificationResponseDto {
+    @ApiModelProperty(value = "2")
     private Long notificationId;
+    @ApiModelProperty(value = "글 제목")
     private String postTitle;
+    @ApiModelProperty(value = "댓글 내용")
     private String commentContent;
+    @ApiModelProperty(value = "2023-03-01")
     private String notifiedDate;
 
     public NotificationResponseDto(Notification notification) {

--- a/src/main/java/com/backend/doyouhave/domain/post/Post.java
+++ b/src/main/java/com/backend/doyouhave/domain/post/Post.java
@@ -42,6 +42,11 @@ public class Post extends BaseTimeEntity {
 
     private String imgSecond;
 
+    private long viewCount;
+
+    // 댓글 수 기준 정렬시 사용(성능 측면에서 조인보다 필드 정렬이 효율적)
+    private long commentNum;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
@@ -55,6 +60,8 @@ public class Post extends BaseTimeEntity {
         this.contactWay = contactWay;
         this.category = category;
         this.tags = tags;
+        this.viewCount = 0; // 전단지 첫 생성시 조회수 0으로 초기화, 상세정보 클릭시 카운팅
+        this.commentNum = this.getCommentList().size();
     }
 
     public void update(PostUpdateRequestDto entity) {
@@ -68,5 +75,9 @@ public class Post extends BaseTimeEntity {
     public void setUser(User user) {
         user.getPosts().add(this);
         this.user = user;
+    }
+
+    public void remove(User user) {
+        user.getPosts().remove(this);
     }
  }

--- a/src/main/java/com/backend/doyouhave/domain/post/dto/PostListResponseDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/post/dto/PostListResponseDto.java
@@ -1,0 +1,29 @@
+package com.backend.doyouhave.domain.post.dto;
+
+import com.backend.doyouhave.domain.post.Post;
+import io.swagger.annotations.ApiModelProperty;
+import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class PostListResponseDto {
+    @ApiParam(value = "글 제목", required = true, example = "Spring")
+    private String title;
+    @ApiParam(value = "글 카테고리", required = true, example = "STUDY")
+    private String categoryKeyword;
+    @ApiParam(value = "글 태그", example = "['MVC', 'SECURITY', 'MYSQL']")
+    private List<String> tags;
+
+    public PostListResponseDto(Post entity) {
+        this.title = entity.getTitle();
+        this.categoryKeyword = entity.getCategory();
+        List<String> entityTags = Arrays.stream(entity.getTags().split(",")).toList();
+        this.tags = entityTags;
+    }
+}

--- a/src/main/java/com/backend/doyouhave/domain/post/dto/PostRequestDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/post/dto/PostRequestDto.java
@@ -1,6 +1,8 @@
 package com.backend.doyouhave.domain.post.dto;
 
 import com.backend.doyouhave.domain.post.Post;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,16 +16,19 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 public class PostRequestDto {
-
+    @ApiModelProperty(value = "고민이 있어요")
     @NotNull
     private String title;
+    @ApiModelProperty(value = "테스트 내용")
     @NotNull
     private String content;
+    @ApiModelProperty(value = "kakaotalk")
     @NotNull
     private String contactWay;
+    @ApiModelProperty(value = "공부")
     @NotNull
     private String categoryKeyword;
-
+    @ApiModelProperty(value = "스프링,자바,프로젝트")
     private String tags;
 
 

--- a/src/main/java/com/backend/doyouhave/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/post/dto/PostResponseDto.java
@@ -1,11 +1,13 @@
 package com.backend.doyouhave.domain.post.dto;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 public class PostResponseDto {
+    @ApiModelProperty(value = "1")
     private Long postId;
 
     public PostResponseDto(Long postId) {

--- a/src/main/java/com/backend/doyouhave/domain/post/dto/PostUpdateRequestDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/post/dto/PostUpdateRequestDto.java
@@ -1,5 +1,6 @@
 package com.backend.doyouhave.domain.post.dto;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,15 +9,18 @@ import javax.validation.constraints.NotNull;
 @Getter
 @NoArgsConstructor
 public class PostUpdateRequestDto {
-
+    @ApiModelProperty(value = "제목")
     @NotNull
     private String title;
+    @ApiModelProperty(value = "내용")
     @NotNull
     private String content;
+    @ApiModelProperty(value = "카카오톡")
     @NotNull
     private String contactWay;
+    @ApiModelProperty(value = "의류")
     @NotNull
     private String categoryKeyword;
-
+    @ApiModelProperty(value = "나이키,아디다스")
     private String tags;
 }

--- a/src/main/java/com/backend/doyouhave/domain/post/dto/PostUpdateResponseDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/post/dto/PostUpdateResponseDto.java
@@ -1,6 +1,7 @@
 package com.backend.doyouhave.domain.post.dto;
 
 import com.backend.doyouhave.domain.post.Post;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,14 +14,15 @@ import java.util.List;
 @NoArgsConstructor
 public class PostUpdateResponseDto {
 
+    @ApiModelProperty(value = "고민이 있어요")
     private String title;
-
+    @ApiModelProperty(value = "테스트")
     private String content;
-
+    @ApiModelProperty(value = "Google Form")
     private String contactWay;
-
+    @ApiModelProperty(value = "MEDICAL")
     private String categoryKeyword;
-
+    @ApiModelProperty(value = "['test1', 'test2', 'test3']")
     private List<String> tags;
 
     private String img;

--- a/src/main/java/com/backend/doyouhave/repository/post/CategoryRepository.java
+++ b/src/main/java/com/backend/doyouhave/repository/post/CategoryRepository.java
@@ -2,7 +2,19 @@ package com.backend.doyouhave.repository.post;
 
 import com.backend.doyouhave.domain.post.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
     Category findByKeyword(String keyword);
+
+    // 전체 전단지 중 인기 태그 TOP5 조회
+    @Query(value = "select tags from category, category_tags group by tags order by count(tags) desc limit 5", nativeQuery = true)
+    List<String> findTop5ByTags();
+
+    // 카테고리별 인기 태그 TOP5 조회
+    @Query(value = "select tags from category c, category_tags where c.keyword = :keyword and c.category_id = category_category_id group by tags order by count(tags) desc limit 5", nativeQuery = true)
+    List<String> findTop5ByCategoryAndTags(@Param("keyword") String keyword);
 }

--- a/src/main/java/com/backend/doyouhave/repository/post/PostRepository.java
+++ b/src/main/java/com/backend/doyouhave/repository/post/PostRepository.java
@@ -1,7 +1,30 @@
 package com.backend.doyouhave.repository.post;
 
 import com.backend.doyouhave.domain.post.Post;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    /* 최근 작성일 기준 */
+    Page<Post> findAll(Pageable pageable);
+    Page<Post> findByCategoryAndTagsContaining(@Param("keyword") String keyword, @Param("tag") String tag, Pageable pageable);
+    Page<Post> findByCategoryOrTagsContaining(@Param("keyword") String keyword, @Param("tag") String tag, Pageable pageable);
+
+    /* 조회수 기준 */
+    Page<Post> findAllByOrderByViewCountDesc(Pageable pageable);
+    Page<Post> findByCategoryAndTagsContainingOrderByViewCountDesc(@Param("keyword") String keyword, @Param("tag") String tag, Pageable pageable);
+    Page<Post> findByCategoryOrTagsContainingOrderByViewCountDesc(@Param("keyword") String keyword, @Param("tag") String tag, Pageable pageable);
+
+    /* 댓글 수 기준 */
+    Page<Post> findAllByOrderByCommentNumDesc(Pageable pageable);
+    Page<Post> findByCategoryAndTagsContainingOrderByCommentNumDesc(@Param("keyword") String keyword, @Param("tag") String tag, Pageable pageable);
+    Page<Post> findByCategoryOrTagsContainingOrderByCommentNumDesc(@Param("keyword") String keyword, @Param("tag") String tag, Pageable pageable);
+
 }

--- a/src/main/java/com/backend/doyouhave/service/PostFilterService.java
+++ b/src/main/java/com/backend/doyouhave/service/PostFilterService.java
@@ -1,0 +1,41 @@
+package com.backend.doyouhave.service;
+
+import com.backend.doyouhave.domain.post.dto.PostListResponseDto;
+import com.backend.doyouhave.repository.post.PostRepository;
+import com.backend.doyouhave.service.sorttype.CommentCount;
+import com.backend.doyouhave.service.sorttype.Date;
+import com.backend.doyouhave.service.sorttype.SortWay;
+import com.backend.doyouhave.service.sorttype.View;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class PostFilterService {
+    private final PostRepository postRepository;
+
+    /* 전단지 골목 페이지에서 카테고리 또는 태그에 따라 전단지 리스트 반환 */
+    public Page<PostListResponseDto> findPostByCategoryOrTags(String category, String tag, String sort, Pageable pageable) {
+        Page<PostListResponseDto> postResultList = null;
+        Map<String, SortWay> sortTypeMap = new HashMap<>();
+
+        // 정렬 기본값은 최근 작성일순
+        sortTypeMap.put(null, new Date(postRepository));
+        sortTypeMap.put("DATE", new Date(postRepository));
+        sortTypeMap.put("VIEW", new View(postRepository));
+        sortTypeMap.put("COMMENT", new CommentCount(postRepository));
+        postResultList = sortTypeMap.get(sort).findPostBySortType(category, tag, pageable);
+
+        return postResultList;
+    }
+
+}

--- a/src/main/java/com/backend/doyouhave/service/result/MultiplePageResult.java
+++ b/src/main/java/com/backend/doyouhave/service/result/MultiplePageResult.java
@@ -1,0 +1,9 @@
+package com.backend.doyouhave.service.result;
+
+import lombok.Data;
+import org.springframework.data.domain.Page;
+
+@Data
+public class MultiplePageResult<T> extends Result {
+    private Page<T> pageData;
+}

--- a/src/main/java/com/backend/doyouhave/service/result/ResponseService.java
+++ b/src/main/java/com/backend/doyouhave/service/result/ResponseService.java
@@ -1,5 +1,6 @@
 package com.backend.doyouhave.service.result;
 
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +27,13 @@ public class ResponseService {
         MultipleResult<T> result = new MultipleResult<>();
         setSuccessResult(result);
         result.setData(data);
+        return result;
+    }
+
+    public <T> MultiplePageResult<T> getMultiplePageResult(Page<T> data) {
+        MultiplePageResult<T> result = new MultiplePageResult<>();
+        setSuccessResult(result);
+        result.setPageData(data);
         return result;
     }
 

--- a/src/main/java/com/backend/doyouhave/service/sorttype/CommentCount.java
+++ b/src/main/java/com/backend/doyouhave/service/sorttype/CommentCount.java
@@ -1,0 +1,29 @@
+package com.backend.doyouhave.service.sorttype;
+
+import com.backend.doyouhave.domain.post.dto.PostListResponseDto;
+import com.backend.doyouhave.repository.post.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+@RequiredArgsConstructor
+public class CommentCount implements SortWay{
+    private final PostRepository postRepository;
+    @Override
+    public Page<PostListResponseDto> findPostBySortType(String category, String tag, Pageable pageable) {
+        PageRequest request = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by(Sort.Direction.DESC, "commentNum"));
+        pageable = request;
+
+        Page<PostListResponseDto> pageList = null;
+        if (category == null && tag == null) {
+            pageList = postRepository.findAllByOrderByCommentNumDesc(pageable).map(PostListResponseDto::new);
+        } else if (category != null && tag != null) {
+            pageList = postRepository.findByCategoryAndTagsContainingOrderByCommentNumDesc(category, tag, pageable).map(PostListResponseDto::new);
+        } else {
+            pageList = postRepository.findByCategoryOrTagsContainingOrderByCommentNumDesc(category, tag, pageable).map(PostListResponseDto::new);
+        }
+        return pageList;
+    }
+}

--- a/src/main/java/com/backend/doyouhave/service/sorttype/Date.java
+++ b/src/main/java/com/backend/doyouhave/service/sorttype/Date.java
@@ -1,0 +1,29 @@
+package com.backend.doyouhave.service.sorttype;
+
+import com.backend.doyouhave.domain.post.dto.PostListResponseDto;
+import com.backend.doyouhave.repository.post.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+@RequiredArgsConstructor
+public class Date implements SortWay {
+    private final PostRepository postRepository;
+    @Override
+    public Page<PostListResponseDto> findPostBySortType(String category, String tag, Pageable pageable) {
+        PageRequest request = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by(Sort.Direction.DESC, "createdDate"));
+        pageable = request;
+
+        Page<PostListResponseDto> pageList = null;
+        if(category == null && tag == null) {
+            pageList = postRepository.findAll(pageable).map(PostListResponseDto::new);
+        } else if(category != null && tag != null) {
+            pageList = postRepository.findByCategoryAndTagsContaining(category, tag, pageable).map(PostListResponseDto::new);
+        } else {
+            pageList = postRepository.findByCategoryOrTagsContaining(category, tag, pageable).map(PostListResponseDto::new);
+        }
+        return pageList;
+    }
+}

--- a/src/main/java/com/backend/doyouhave/service/sorttype/SortWay.java
+++ b/src/main/java/com/backend/doyouhave/service/sorttype/SortWay.java
@@ -1,0 +1,9 @@
+package com.backend.doyouhave.service.sorttype;
+
+import com.backend.doyouhave.domain.post.dto.PostListResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface SortWay {
+    public Page<PostListResponseDto> findPostBySortType(String category, String tag, Pageable pageable);
+}

--- a/src/main/java/com/backend/doyouhave/service/sorttype/View.java
+++ b/src/main/java/com/backend/doyouhave/service/sorttype/View.java
@@ -1,0 +1,28 @@
+package com.backend.doyouhave.service.sorttype;
+
+import com.backend.doyouhave.domain.post.dto.PostListResponseDto;
+import com.backend.doyouhave.repository.post.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+@RequiredArgsConstructor
+public class View implements SortWay {
+    private final PostRepository postRepository;
+    @Override
+    public Page<PostListResponseDto> findPostBySortType(String category, String tag, Pageable pageable) {
+        PageRequest request = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by(Sort.Direction.DESC, "viewCount"));
+        pageable = request;
+        Page<PostListResponseDto> pageList = null;
+        if(category==null && tag == null) {
+            pageList = postRepository.findAllByOrderByViewCountDesc(pageable).map(PostListResponseDto::new);
+        } else if(category!=null && tag != null) {
+            pageList  = postRepository.findByCategoryAndTagsContainingOrderByViewCountDesc(category, tag, pageable).map(PostListResponseDto::new);
+        } else {
+            pageList = postRepository.findByCategoryOrTagsContainingOrderByViewCountDesc(category, tag, pageable).map(PostListResponseDto::new);
+        }
+        return pageList;
+    }
+}


### PR DESCRIPTION
- 카테고리, 태그, 정렬 기준별 전단지 기본 정보 조회 API 추가
- 인기 태그 API 추가 (카테고리별 전단지 기준으로 상위 5개의 태그가 조회)

- 전단지 조회 수, 댓글 수 필드를 추가하였습니다.
- 댓글 생성 및 삭제시 도메인 비즈니스 로직을 추가하였습니다. (전단지 관계 세팅, 댓글 수 카운팅)