### PR TITLE
feat: 전단지 검색용 파라미터 및 서비스 로직 추가

### DIFF
--- a/src/main/java/com/backend/doyouhave/controller/MainController.java
+++ b/src/main/java/com/backend/doyouhave/controller/MainController.java
@@ -40,7 +40,7 @@ public class MainController {
         return ResponseEntity.ok(responseService.getSingleResult(new MainInfoDto(countPost.get("allCount"), countPost.get("todayCount"))));
     }
 
-    /* 전단지 조회 API */
+    /* 전단지 조회 API (+ 검색) */
     @GetMapping("/list")
     @ApiOperation(value = "전단지 리스트", notes = "선택한 카테고리 및 정렬순에 따라 전단지를 보여준다.")
     @ApiResponses({
@@ -52,10 +52,13 @@ public class MainController {
             @PathVariable Long userId,
             @RequestParam(name="category", required = false) String category,
             @RequestParam(name="tag", required = false) String tag,
+            @RequestParam(name="search", required = false) String search,
             @RequestParam(name="sort", required = false) String sort,
             @PageableDefault(size=20) Pageable pageable) {
 
-        Page<PostListResponseDto> response = postFilterService.findPostByCategoryOrTags(category, tag, sort, pageable);
+        // 검색했을 때와 검색하지 않았을 때를 구분
+        Page<PostListResponseDto> response = search == null ? postFilterService.findPostByCategoryOrTags(category, tag, sort, pageable) :
+                                                                postFilterService.findPostByCategoryAndSearch(category, search, sort, pageable);
         return ResponseEntity.ok(responseService.getMultiplePageResult(response));
     }
 

--- a/src/main/java/com/backend/doyouhave/repository/post/PostRepository.java
+++ b/src/main/java/com/backend/doyouhave/repository/post/PostRepository.java
@@ -12,19 +12,11 @@ import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    /* 최근 작성일 기준 */
+    /* 카테고리, 태그 및 정렬별 전단지 조회  */
     Page<Post> findAll(Pageable pageable);
     Page<Post> findByCategoryAndTagsContaining(@Param("keyword") String keyword, @Param("tag") String tag, Pageable pageable);
     Page<Post> findByCategoryOrTagsContaining(@Param("keyword") String keyword, @Param("tag") String tag, Pageable pageable);
 
-    /* 조회수 기준 */
-    Page<Post> findAllByOrderByViewCountDesc(Pageable pageable);
-    Page<Post> findByCategoryAndTagsContainingOrderByViewCountDesc(@Param("keyword") String keyword, @Param("tag") String tag, Pageable pageable);
-    Page<Post> findByCategoryOrTagsContainingOrderByViewCountDesc(@Param("keyword") String keyword, @Param("tag") String tag, Pageable pageable);
-
-    /* 댓글 수 기준 */
-    Page<Post> findAllByOrderByCommentNumDesc(Pageable pageable);
-    Page<Post> findByCategoryAndTagsContainingOrderByCommentNumDesc(@Param("keyword") String keyword, @Param("tag") String tag, Pageable pageable);
-    Page<Post> findByCategoryOrTagsContainingOrderByCommentNumDesc(@Param("keyword") String keyword, @Param("tag") String tag, Pageable pageable);
-
+    /* 전단지 검색 조회 */
+    Page<Post> findByCategoryAndTitleContainingOrContentContaining(@Param("keyword") String keyword, @Param("search") String title, @Param("search") String content, Pageable pageable);
 }

--- a/src/main/java/com/backend/doyouhave/service/PostFilterService.java
+++ b/src/main/java/com/backend/doyouhave/service/PostFilterService.java
@@ -23,7 +23,7 @@ import java.util.Map;
 public class PostFilterService {
     private final PostRepository postRepository;
 
-    /* 전단지 골목 페이지에서 카테고리 또는 태그에 따라 전단지 리스트 반환 */
+    /* 전단지 골목 페이지에서 카테고리 또는 태그에 따라 전단지 기본 정보 리스트 반환 */
     public Page<PostListResponseDto> findPostByCategoryOrTags(String category, String tag, String sort, Pageable pageable) {
         Page<PostListResponseDto> postResultList = null;
         Map<String, SortWay> sortTypeMap = new HashMap<>();
@@ -35,6 +35,22 @@ public class PostFilterService {
         sortTypeMap.put("COMMENT", new CommentCount(postRepository));
         postResultList = sortTypeMap.get(sort).findPostBySortType(category, tag, pageable);
 
+        return postResultList;
+    }
+
+    /* 제목 기준 전단지 검색용 */
+    public Page<PostListResponseDto> findPostByCategoryAndSearch(String category, String search, String sort, Pageable pageable) {
+        Page<PostListResponseDto> postResultList = null;
+        try {
+            PageRequest request
+                    = sort == null || sort.equals("DATE") ? PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by(Sort.Direction.DESC, "createdDate"))
+                    : sort.equals("VIEW") ? PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by(Sort.Direction.DESC, "viewCount"))
+                    : sort.equals("COMMENT") ? PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by(Sort.Direction.DESC, "commentNum")) : null;
+
+            postResultList = postRepository.findByCategoryAndTitleContainingOrContentContaining(category, search, search, request).map(PostListResponseDto::new);
+        } catch (NoSuchFieldError e) {
+            e.printStackTrace();
+        }
         return postResultList;
     }
 

--- a/src/main/java/com/backend/doyouhave/service/sorttype/CommentCount.java
+++ b/src/main/java/com/backend/doyouhave/service/sorttype/CommentCount.java
@@ -14,15 +14,14 @@ public class CommentCount implements SortWay{
     @Override
     public Page<PostListResponseDto> findPostBySortType(String category, String tag, Pageable pageable) {
         PageRequest request = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by(Sort.Direction.DESC, "commentNum"));
-        pageable = request;
 
         Page<PostListResponseDto> pageList = null;
         if (category == null && tag == null) {
-            pageList = postRepository.findAllByOrderByCommentNumDesc(pageable).map(PostListResponseDto::new);
+            pageList = postRepository.findAll(request).map(PostListResponseDto::new);
         } else if (category != null && tag != null) {
-            pageList = postRepository.findByCategoryAndTagsContainingOrderByCommentNumDesc(category, tag, pageable).map(PostListResponseDto::new);
+            pageList = postRepository.findByCategoryAndTagsContaining(category, tag, request).map(PostListResponseDto::new);
         } else {
-            pageList = postRepository.findByCategoryOrTagsContainingOrderByCommentNumDesc(category, tag, pageable).map(PostListResponseDto::new);
+            pageList = postRepository.findByCategoryOrTagsContaining(category, tag, request).map(PostListResponseDto::new);
         }
         return pageList;
     }

--- a/src/main/java/com/backend/doyouhave/service/sorttype/Date.java
+++ b/src/main/java/com/backend/doyouhave/service/sorttype/Date.java
@@ -14,15 +14,14 @@ public class Date implements SortWay {
     @Override
     public Page<PostListResponseDto> findPostBySortType(String category, String tag, Pageable pageable) {
         PageRequest request = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by(Sort.Direction.DESC, "createdDate"));
-        pageable = request;
 
         Page<PostListResponseDto> pageList = null;
         if(category == null && tag == null) {
-            pageList = postRepository.findAll(pageable).map(PostListResponseDto::new);
+            pageList = postRepository.findAll(request).map(PostListResponseDto::new);
         } else if(category != null && tag != null) {
-            pageList = postRepository.findByCategoryAndTagsContaining(category, tag, pageable).map(PostListResponseDto::new);
+            pageList = postRepository.findByCategoryAndTagsContaining(category, tag, request).map(PostListResponseDto::new);
         } else {
-            pageList = postRepository.findByCategoryOrTagsContaining(category, tag, pageable).map(PostListResponseDto::new);
+            pageList = postRepository.findByCategoryOrTagsContaining(category, tag, request).map(PostListResponseDto::new);
         }
         return pageList;
     }

--- a/src/main/java/com/backend/doyouhave/service/sorttype/View.java
+++ b/src/main/java/com/backend/doyouhave/service/sorttype/View.java
@@ -14,14 +14,14 @@ public class View implements SortWay {
     @Override
     public Page<PostListResponseDto> findPostBySortType(String category, String tag, Pageable pageable) {
         PageRequest request = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by(Sort.Direction.DESC, "viewCount"));
-        pageable = request;
+
         Page<PostListResponseDto> pageList = null;
         if(category==null && tag == null) {
-            pageList = postRepository.findAllByOrderByViewCountDesc(pageable).map(PostListResponseDto::new);
+            pageList = postRepository.findAll(request).map(PostListResponseDto::new);
         } else if(category!=null && tag != null) {
-            pageList  = postRepository.findByCategoryAndTagsContainingOrderByViewCountDesc(category, tag, pageable).map(PostListResponseDto::new);
+            pageList  = postRepository.findByCategoryAndTagsContaining(category, tag, request).map(PostListResponseDto::new);
         } else {
-            pageList = postRepository.findByCategoryOrTagsContainingOrderByViewCountDesc(category, tag, pageable).map(PostListResponseDto::new);
+            pageList = postRepository.findByCategoryOrTagsContaining(category, tag, request).map(PostListResponseDto::new);
         }
         return pageList;
     }


### PR DESCRIPTION
- 전단지 제목 또는 내용 기준 검색 파라미터 추가
- 정렬시 쿼리가 중첩되는 부분이 있어 동일한 쿼리는 제거하여 로직을 수정하였습니다.