### PR TITLE
Feat: 게시글 정보 반환 API

### DIFF
--- a/src/main/java/com/backend/doyouhave/config/SecurityConfig.java
+++ b/src/main/java/com/backend/doyouhave/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import com.backend.doyouhave.jwt.JwtAuthenticationFilter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -43,7 +44,8 @@ public class SecurityConfig {
                 "/api/users/kakao-login",
                 "/api/users/naver-login",
                 "/api/auth/token-refresh"
-        );
+        ).mvcMatchers(HttpMethod.GET, "/api/users/posts/**");
+
     }
 
     @Bean

--- a/src/main/java/com/backend/doyouhave/config/SwaggerConfig.java
+++ b/src/main/java/com/backend/doyouhave/config/SwaggerConfig.java
@@ -37,7 +37,7 @@ public class SwaggerConfig {
     }
 
     private ApiKey apiKey() {
-        return new ApiKey("JWT", "Bearer", "header");
+        return new ApiKey("Authorization", "Authorization Header (Bearer Token)", "header");
     }
 
     private SecurityContext securityContext() {
@@ -48,7 +48,8 @@ public class SwaggerConfig {
         AuthorizationScope authorizationScope = new AuthorizationScope("global", "accessEverything");
         AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
         authorizationScopes[0] = authorizationScope;
-        return Arrays.asList(new SecurityReference("JWT", authorizationScopes));
+        System.out.println("authorizationScopes = " + authorizationScopes);
+        return Arrays.asList(new SecurityReference("Authorization", authorizationScopes));
     }
 
     private ApiInfo apiInfo() {

--- a/src/main/java/com/backend/doyouhave/controller/PostController.java
+++ b/src/main/java/com/backend/doyouhave/controller/PostController.java
@@ -1,28 +1,15 @@
 package com.backend.doyouhave.controller;
 
-import com.backend.doyouhave.domain.notification.dto.NotificationResponseDto;
 import com.backend.doyouhave.domain.post.Post;
-import com.backend.doyouhave.domain.post.dto.PostRequestDto;
-import com.backend.doyouhave.domain.post.dto.PostResponseDto;
-import com.backend.doyouhave.domain.post.dto.PostUpdateRequestDto;
-import com.backend.doyouhave.domain.post.dto.PostUpdateResponseDto;
+import com.backend.doyouhave.domain.post.dto.*;
 import com.backend.doyouhave.domain.user.User;
-import com.backend.doyouhave.exception.ExceptionCode;
-import com.backend.doyouhave.exception.ExceptionResponse;
-import com.backend.doyouhave.exception.NotFoundException;
-import com.backend.doyouhave.jwt.UserPrincipal;
-import com.backend.doyouhave.repository.user.UserRepository;
 import com.backend.doyouhave.service.PostService;
-import com.backend.doyouhave.service.UserService;
-import com.backend.doyouhave.service.result.MultipleResult;
 import com.backend.doyouhave.service.result.ResponseService;
 import com.backend.doyouhave.service.result.Result;
 import com.backend.doyouhave.service.result.SingleResult;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.Response;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -31,9 +18,9 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.net.URI;
-import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("api/users")
@@ -67,7 +54,7 @@ public class PostController {
     @ApiOperation(value = "전단지 수정 정보 조회 API", notes = "수정할 전단지의 기존 정보를 반환한다.")
     public ResponseEntity<SingleResult<PostUpdateResponseDto>> updatePostInfo(
             @PathVariable Long postId) {
-        PostUpdateResponseDto updateResponse = postService.getPostInfo(postId);
+        PostUpdateResponseDto updateResponse = postService.getPostInfoForUpdate(postId);
         return ResponseEntity.ok(responseService.getSingleResult(updateResponse));
     }
 
@@ -108,6 +95,15 @@ public class PostController {
         }
         postService.markPost(userId, postId, mark);
         return ResponseEntity.ok(responseService.getSuccessResult());
+    }
+
+    @GetMapping("/posts/{postId}")
+    @ApiOperation(value = "전단지 정보 반환 API", notes = "전단지 정보를 반환한다.")
+    public ResponseEntity<SingleResult<PostInfoDto>> getPostInfo(
+            @AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : #this") Long userId,
+            @PathVariable Long postId) {
+        PostInfoDto result = postService.getPostInfo(userId, postId);
+        return ResponseEntity.ok(responseService.getSingleResult(result));
     }
 
 }

--- a/src/main/java/com/backend/doyouhave/controller/PostController.java
+++ b/src/main/java/com/backend/doyouhave/controller/PostController.java
@@ -89,11 +89,11 @@ public class PostController {
     public ResponseEntity<Result> bookMarkPost(
             @PathVariable Long postId,
             @RequestParam(name = "mark") boolean mark,
-             @AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : userId") Long userId) {
+             @AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : #this") Long userId) {
         if(userId == null) {
             return ResponseEntity.ok(responseService.getFailureResult());
         }
-        postService.markPost(userId, postId, mark);
+        postService.markPost(postId, userId, mark);
         return ResponseEntity.ok(responseService.getSuccessResult());
     }
 

--- a/src/main/java/com/backend/doyouhave/domain/comment/dto/CommentResponseDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/comment/dto/CommentResponseDto.java
@@ -1,6 +1,7 @@
 package com.backend.doyouhave.domain.comment.dto;
 
 import com.backend.doyouhave.domain.comment.Comment;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -19,6 +20,7 @@ public class CommentResponseDto {
 
     @ApiModelProperty(value = "댓글 생성 날짜", required = true, example = "2022~")
     @Schema(description = "댓글 생성 날짜")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private final LocalDateTime createdDate;
 
     @ApiModelProperty(value = "댓글 내용", required = true, example = "댓글 내용 예시")

--- a/src/main/java/com/backend/doyouhave/domain/comment/dto/CommentResponseDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/comment/dto/CommentResponseDto.java
@@ -6,6 +6,8 @@ import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Schema(description = "CommentResponseDTO")
 @ApiModel(description = "CommentResponseDTO")
@@ -14,6 +16,10 @@ public class CommentResponseDto {
     @ApiModelProperty(value = "댓글 아이디", required = true, example = "1")
     @Schema(description = "댓글 아이디")
     private final Long commentId;
+
+    @ApiModelProperty(value = "댓글 생성 날짜", required = true, example = "2022~")
+    @Schema(description = "댓글 생성 날짜")
+    private final LocalDateTime createdDate;
 
     @ApiModelProperty(value = "댓글 내용", required = true, example = "댓글 내용 예시")
     @Schema(description = "댓글 내용")
@@ -41,6 +47,7 @@ public class CommentResponseDto {
 
     public CommentResponseDto(Comment comment) {
         this.commentId = comment.getId();
+        this.createdDate = comment.getCreatedDate();
         this.content = comment.getContent();
         // 원 댓글일 경우에는 parentId가 자기 Id
         this.parentId = comment.getParentId();

--- a/src/main/java/com/backend/doyouhave/domain/post/dto/PostInfoDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/post/dto/PostInfoDto.java
@@ -1,0 +1,72 @@
+package com.backend.doyouhave.domain.post.dto;
+
+import com.backend.doyouhave.domain.post.Post;
+import com.backend.doyouhave.domain.user.dto.LoginResponseDto;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor
+public class PostInfoDto {
+
+    @ApiModelProperty(value = "1")
+    private Long postId;
+    @ApiModelProperty(value = "2022~~")
+    private LocalDateTime createdDate;
+    @ApiModelProperty(value = "true")
+    private Boolean isWriter;
+    @ApiModelProperty(value = "고민이 있어요")
+    private String title;
+    @ApiModelProperty(value = "테스트")
+    private String content;
+    @ApiModelProperty(value = "Google Form")
+    private String contactWay;
+    @ApiModelProperty(value = "MEDICAL")
+    private String categoryKeyword;
+    @ApiModelProperty(value = "['test1', 'test2', 'test3']")
+    private List<String> tags;
+    private String img;
+    private String imgSecond;
+    @ApiModelProperty(value = "0")
+    private Long viewCount;
+    @ApiModelProperty(value = "0")
+    private Long commentNum;
+    @ApiModelProperty(value = "false")
+    private Boolean mark;
+    @ApiModelProperty(value = "0")
+    private Long markNum;
+
+    @Builder
+    public PostInfoDto(Post entity, Long userId, Boolean mark, Long markNum) {
+        this.postId = entity.getId();
+        this.createdDate = entity.getCreatedDate();
+        this.isWriter = userId != null && Objects.equals(entity.getUser().getId(), userId);
+        this.title = entity.getTitle();
+        this.content = entity.getContent();
+        this.contactWay = entity.getContactWay();
+        this.categoryKeyword = entity.getCategory();
+        this.tags = Arrays.stream(entity.getTags().split(",")).toList();
+        this.img = entity.getImg();
+        this.imgSecond = entity.getImgSecond();
+        this.viewCount = entity.getViewCount();
+        this.commentNum = entity.getCommentNum();
+        this.mark = mark;
+        this.markNum = markNum;
+    }
+
+    public static PostInfoDto from(Post entity, Long userId, Boolean mark, Long markNum) {
+        return PostInfoDto.builder()
+                .entity(entity)
+                .userId(userId)
+                .mark(mark)
+                .markNum(markNum)
+                .build();
+    }
+}

--- a/src/main/java/com/backend/doyouhave/domain/post/dto/PostInfoDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/post/dto/PostInfoDto.java
@@ -22,6 +22,8 @@ public class PostInfoDto {
     @ApiModelProperty(value = "2022~~")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime createdDate;
+    @ApiModelProperty(value = "1")
+    private Long writerId;
     @ApiModelProperty(value = "true")
     private Boolean isWriter;
     @ApiModelProperty(value = "고민이 있어요")
@@ -49,6 +51,7 @@ public class PostInfoDto {
     public PostInfoDto(Post entity, Long userId, Boolean mark, Long markNum) {
         this.postId = entity.getId();
         this.createdDate = entity.getCreatedDate();
+        this.writerId = entity.getUser().getId();
         this.isWriter = userId != null && Objects.equals(entity.getUser().getId(), userId);
         this.title = entity.getTitle();
         this.content = entity.getContent();

--- a/src/main/java/com/backend/doyouhave/domain/post/dto/PostInfoDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/post/dto/PostInfoDto.java
@@ -2,6 +2,7 @@ package com.backend.doyouhave.domain.post.dto;
 
 import com.backend.doyouhave.domain.post.Post;
 import com.backend.doyouhave.domain.user.dto.LoginResponseDto;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,6 +20,7 @@ public class PostInfoDto {
     @ApiModelProperty(value = "1")
     private Long postId;
     @ApiModelProperty(value = "2022~~")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime createdDate;
     @ApiModelProperty(value = "true")
     private Boolean isWriter;

--- a/src/main/java/com/backend/doyouhave/jwt/UserPrincipal.java
+++ b/src/main/java/com/backend/doyouhave/jwt/UserPrincipal.java
@@ -2,6 +2,7 @@ package com.backend.doyouhave.jwt;
 
 
 import com.backend.doyouhave.domain.user.User;
+import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -9,10 +10,11 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.Collection;
 import java.util.Collections;
 
+@Getter
 public class UserPrincipal implements UserDetails {
 
-    private final Long userId;
-    private final Collection<? extends GrantedAuthority> authorities;
+    private Long userId;
+    private Collection<? extends GrantedAuthority> authorities;
 
     public UserPrincipal(Long userId, Collection<? extends GrantedAuthority> authorities) {
         this.userId = userId;

--- a/src/main/java/com/backend/doyouhave/repository/user/UserLikesRepository.java
+++ b/src/main/java/com/backend/doyouhave/repository/user/UserLikesRepository.java
@@ -1,7 +1,12 @@
 package com.backend.doyouhave.repository.user;
 
+import com.backend.doyouhave.domain.post.Post;
+import com.backend.doyouhave.domain.user.User;
 import com.backend.doyouhave.domain.user.UserLikes;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserLikesRepository extends JpaRepository<UserLikes, Long> {
+    Optional<UserLikes> findByUserIdAndPostId(Long userId, Long postId);
 }

--- a/src/main/java/com/backend/doyouhave/service/PostService.java
+++ b/src/main/java/com/backend/doyouhave/service/PostService.java
@@ -175,7 +175,6 @@ public class PostService {
 
     /* 북마크 처리 (상세 정보 dto에서도 북마크 여부 반환 필요) */
     public void markPost(Long postId, Long userId, boolean mark) {
-
         User user =  userRepository.findById(userId).orElseThrow();
         Post markedPost = postRepository.findById(postId).orElseThrow();
 
@@ -183,7 +182,7 @@ public class PostService {
                                         .markedUser(user)
                                         .markedPost(markedPost)
                                         .build();
-        if(mark == false) {
+        if(mark) {
             userLikes.setUser(user);
             userLikes.setPost(markedPost);
             userLikesRepository.save(userLikes);

--- a/src/main/java/com/backend/doyouhave/service/PostService.java
+++ b/src/main/java/com/backend/doyouhave/service/PostService.java
@@ -1,7 +1,9 @@
 package com.backend.doyouhave.service;
 
+import com.backend.doyouhave.domain.comment.dto.CommentResponseDto;
 import com.backend.doyouhave.domain.post.Category;
 import com.backend.doyouhave.domain.post.Post;
+import com.backend.doyouhave.domain.post.dto.PostInfoDto;
 import com.backend.doyouhave.domain.post.dto.PostListResponseDto;
 import com.backend.doyouhave.domain.post.dto.PostUpdateRequestDto;
 import com.backend.doyouhave.domain.post.dto.PostUpdateResponseDto;
@@ -77,7 +79,7 @@ public class PostService {
     }
 
     /* 전단지 수정 정보 반환 */
-    public PostUpdateResponseDto getPostInfo(Long postId) {
+    public PostUpdateResponseDto getPostInfoForUpdate(Long postId) {
         Post post = postRepository.findById(postId).orElseThrow(() -> new NotFoundException());
         PostUpdateResponseDto updateResponse = PostUpdateResponseDto.builder().entity(post).build();
         return updateResponse;
@@ -190,4 +192,14 @@ public class PostService {
             userLikesRepository.delete(userLikes);
         }
     }
+
+    /* 게시글 정보 반환 */
+    public PostInfoDto getPostInfo(Long userId, Long postId) {
+        Post post = postRepository.findById(postId).orElseThrow(NotFoundException::new);
+        Boolean mark = userId != null && userLikesRepository.findByUserIdAndPostId(userId, postId).isPresent();
+        Long markNum = (long) post.getUserLikes().size();
+
+        return PostInfoDto.from(post, userId, mark, markNum);
+    }
+
 }

--- a/src/main/java/com/backend/doyouhave/service/PostService.java
+++ b/src/main/java/com/backend/doyouhave/service/PostService.java
@@ -199,6 +199,10 @@ public class PostService {
         Boolean mark = userId != null && userLikesRepository.findByUserIdAndPostId(userId, postId).isPresent();
         Long markNum = (long) post.getUserLikes().size();
 
+        post.setCommentNum(post.getCommentList().size());
+        post.setViewCount(post.getViewCount()+1);
+        postRepository.save(post);
+
         return PostInfoDto.from(post, userId, mark, markNum);
     }
 


### PR DESCRIPTION
**게시글 정보를 반환하는 API**입니다. (댓글은 page처리 때문에 따로 하려 합니다.)
중복되는 url이 있어서 댓글관련 API는 comment를 붙였습니다.
swagger에서 인증을 할 때, JWT로 되어 있는데 제가 인증을 Authorization로 구현해놔서 Authorization로 수정했습니다.
- **인증코드 입력하는 곳에 "Bearer {accessToken}"으로 입력해주세요!**

기획서를 보니 연락수단이 중복체크인 것 같더라고요. 다음 정기회의 때 한번 여쭤볼게요!