### PR TITLE
refactor: 북마크 추가 및 삭제 로직 분리

### DIFF
--- a/src/main/java/com/backend/doyouhave/controller/PostController.java
+++ b/src/main/java/com/backend/doyouhave/controller/PostController.java
@@ -32,14 +32,14 @@ public class PostController {
     @PostMapping(value = "/posts", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ApiOperation(value = "전단지 등록 API", notes = "전단지를 등록한다. (사진 최대 2개 선택, 태그 최대 3개 입력)")
     public ResponseEntity<SingleResult<PostResponseDto>> savePost(
-//            @AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : userId") Long userId,
+            @AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : #this") Long userId,
             @RequestPart PostRequestDto postRequestDto,
             @Parameter(description = "multipart/form-data 형식의 이미지를 input 최대 2개로 입력받습니다.")
             @RequestPart(required = false) MultipartFile imageFile,
             @RequestPart(required = false) MultipartFile imageFileSecond) throws IOException {
 
         Post post = postRequestDto.toEntity();
-        Long savedPostId = postService.savePost(post, imageFile, imageFileSecond);
+        Long savedPostId = postService.savePost(userId, post, imageFile, imageFileSecond);
 
         // 등록 후 작성한 페이지로 이동
         URI uri = ServletUriComponentsBuilder.fromCurrentContextPath()
@@ -79,8 +79,9 @@ public class PostController {
     @DeleteMapping("/posts/{postId}")
     @ApiOperation(value = "전단지 삭제 API", notes = "전단지를 삭제한다.")
     public ResponseEntity<Result> deletePost(
+            @AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : #this") Long userId,
             @PathVariable Long postId) throws IOException {
-        postService.deletePost(postId);
+        postService.deletePost(userId, postId);
         return ResponseEntity.ok(responseService.getSuccessResult());
     }
 
@@ -88,12 +89,17 @@ public class PostController {
     @ApiOperation(value = "전단지 북마크 API", notes = "전단지를 북마크한다.")
     public ResponseEntity<Result> bookMarkPost(
             @PathVariable Long postId,
-            @RequestParam(name = "mark") boolean mark,
+            @RequestParam(name = "mark") Boolean mark,
              @AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : #this") Long userId) {
         if(userId == null) {
             return ResponseEntity.ok(responseService.getFailureResult());
         }
-        postService.markPost(postId, userId, mark);
+
+        if (mark == true) {
+            postService.markPost(postId, userId);
+        } else {
+            postService.markDeletePost(postId, userId);
+        }
         return ResponseEntity.ok(responseService.getSuccessResult());
     }
 

--- a/src/main/java/com/backend/doyouhave/domain/post/Post.java
+++ b/src/main/java/com/backend/doyouhave/domain/post/Post.java
@@ -35,6 +35,9 @@ public class Post extends BaseTimeEntity {
     private String contactWay;
 
     @Column(nullable = false)
+    private String contactUrl;
+
+    @Column(nullable = false)
     private String category;
 
     private String tags;
@@ -58,10 +61,11 @@ public class Post extends BaseTimeEntity {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<UserLikes> userLikes = new ArrayList<>();
 
-    public void create(String title, String content, String contactWay, String category, String tags) {
+    public void create(String title, String content, String contactWay, String contactUrl, String category, String tags) {
         this.title = title;
         this.content = content;
         this.contactWay = contactWay;
+        this.contactUrl = contactUrl;
         this.category = category;
         this.tags = tags;
         this.viewCount = 0; // 전단지 첫 생성시 조회수 0으로 초기화, 상세정보 클릭시 카운팅
@@ -72,6 +76,7 @@ public class Post extends BaseTimeEntity {
         this.title = entity.getTitle();
         this.content = entity.getContent();
         this.contactWay = entity.getContactWay();
+        this.contactUrl = entity.getContactUrl();
         this.category = entity.getCategoryKeyword();
         this.tags = entity.getTags();
     }

--- a/src/main/java/com/backend/doyouhave/domain/post/dto/PostInfoDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/post/dto/PostInfoDto.java
@@ -32,6 +32,8 @@ public class PostInfoDto {
     private String content;
     @ApiModelProperty(value = "Google Form")
     private String contactWay;
+    @ApiModelProperty(value = "http://open.kakao.com/o/sDMnCBS")
+    private String contactUrl;
     @ApiModelProperty(value = "MEDICAL")
     private String categoryKeyword;
     @ApiModelProperty(value = "['test1', 'test2', 'test3']")
@@ -56,6 +58,7 @@ public class PostInfoDto {
         this.title = entity.getTitle();
         this.content = entity.getContent();
         this.contactWay = entity.getContactWay();
+        this.contactUrl = entity.getContactUrl();
         this.categoryKeyword = entity.getCategory();
         this.tags = Arrays.stream(entity.getTags().split(",")).toList();
         this.img = entity.getImg();

--- a/src/main/java/com/backend/doyouhave/domain/post/dto/PostRequestDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/post/dto/PostRequestDto.java
@@ -25,6 +25,9 @@ public class PostRequestDto {
     @ApiModelProperty(value = "kakaotalk")
     @NotNull
     private String contactWay;
+    @ApiModelProperty(value = "http://open.kakao.com/o/sDMnCBS")
+    @NotNull
+    private String contactUrl;
     @ApiModelProperty(value = "공부")
     @NotNull
     private String categoryKeyword;
@@ -33,17 +36,18 @@ public class PostRequestDto {
 
 
     @Builder
-    public PostRequestDto(String title, String content, String contactWay, String categoryKeyword, String tags) {
+    public PostRequestDto(String title, String content, String contactWay, String contactUrl, String categoryKeyword, String tags) {
         this.title = title;
         this.content = content;
         this.contactWay = contactWay;
+        this.contactUrl = contactUrl;
         this.categoryKeyword = categoryKeyword;
         this.tags = tags;
     }
 
     public Post toEntity() {
         Post post = new Post();
-        post.create(title, content, contactWay, categoryKeyword, tags);
+        post.create(title, content, contactWay, contactUrl, categoryKeyword, tags);
         return post;
     }
 }

--- a/src/main/java/com/backend/doyouhave/domain/post/dto/PostUpdateRequestDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/post/dto/PostUpdateRequestDto.java
@@ -18,6 +18,9 @@ public class PostUpdateRequestDto {
     @ApiModelProperty(value = "카카오톡")
     @NotNull
     private String contactWay;
+    @ApiModelProperty(value = "http://open.kakao.com/o/sDMnCBS")
+    @NotNull
+    private String contactUrl;
     @ApiModelProperty(value = "의류")
     @NotNull
     private String categoryKeyword;

--- a/src/main/java/com/backend/doyouhave/domain/post/dto/PostUpdateResponseDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/post/dto/PostUpdateResponseDto.java
@@ -20,6 +20,8 @@ public class PostUpdateResponseDto {
     private String content;
     @ApiModelProperty(value = "Google Form")
     private String contactWay;
+    @ApiModelProperty(value = "http://open.kakao.com/o/sDMnCBS")
+    private String contactUrl;
     @ApiModelProperty(value = "MEDICAL")
     private String categoryKeyword;
     @ApiModelProperty(value = "['test1', 'test2', 'test3']")
@@ -34,6 +36,7 @@ public class PostUpdateResponseDto {
         this.title = entity.getTitle();
         this.content = entity.getContent();
         this.contactWay = entity.getContactWay();
+        this.contactUrl = entity.getContactUrl();
         this.categoryKeyword = entity.getCategory();
         List<String> entityTags = Arrays.stream(entity.getTags().split(",")).toList();
         this.tags = entityTags;

--- a/src/main/java/com/backend/doyouhave/domain/user/UserLikes.java
+++ b/src/main/java/com/backend/doyouhave/domain/user/UserLikes.java
@@ -38,8 +38,8 @@ public class UserLikes extends BaseTimeEntity {
     }
 
     public void deleteUserAndPost(User markedUser, Post markedPost) {
-        user.getUserLikes().remove(markedUser);
-        post.getUserLikes().remove(markedPost);
+        markedUser.getUserLikes().remove(this);
+        markedPost.getUserLikes().remove(this);
     }
 
     @Builder

--- a/src/main/java/com/backend/doyouhave/repository/user/UserLikesRepository.java
+++ b/src/main/java/com/backend/doyouhave/repository/user/UserLikesRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 
 public interface UserLikesRepository extends JpaRepository<UserLikes, Long> {
     Optional<UserLikes> findByUserIdAndPostId(Long userId, Long postId);
+    UserLikes findNotOptionalByUserIdAndPostId(Long userId, Long postId);
 }


### PR DESCRIPTION
- 테스트시 북마크 삭제가 올바르게 되지 않아 로직을 분리하여 해결하였습니다.
- 전단지 작성시 연락 수단과 URL이 따로 있어야 할 거 같아 필드를 추가하고 관련된 DTO를 수정하였습니다.
ex) "카카오톡", "http://open.kakao.com/o/sDMnCB"

- 소셜 로그인 후 인증된 회원 아이디를 이용해 User - Post 관계 매핑 로직을 추가하였습니다. 
참고 : 테스트시 `401 Authorized` 에러가 뜬다면 소셜로그인 후 얻은 AccessToken 값을 아래 사진처럼 설정하시면 정상적으로 동작하게 됩니다.

![image](https://user-images.githubusercontent.com/76730470/219790768-f2dbf9d4-766f-41f5-98ca-ff957d498d28.JPG)
