### PR TITLE
feat: 전단지 골목 페이지 디자인 변경으로 전단지 기본 정보 DTO에 이미지 URL 추가

### DIFF
--- a/src/main/java/com/backend/doyouhave/domain/post/dto/PostListResponseDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/post/dto/PostListResponseDto.java
@@ -21,11 +21,14 @@ public class PostListResponseDto {
     private String categoryKeyword;
     @ApiParam(value = "글 태그", example = "['MVC', 'SECURITY', 'MYSQL']")
     private List<String> tags;
+    @ApiParam(value = "이미지 URL (메인 이미지)")
+    private String imgUrl;
 
     public PostListResponseDto(Post entity) {
         this.title = entity.getTitle();
         this.categoryKeyword = entity.getCategory();
         List<String> entityTags = Arrays.stream(entity.getTags().split(",")).toList();
         this.tags = entityTags;
+        this.imgUrl = entity.getImg();
     }
 }


### PR DESCRIPTION
- 전단지 골목 페이지에서 전단지 호버시 이미지가 노출되는 걸로 변경되어 전단지 기본 정보에 이미지 URL을 포함시켰습니다.