### PR TITLE
Feat: 댓글 목록 반환 API

### DIFF
--- a/src/main/java/com/backend/doyouhave/controller/CommentController.java
+++ b/src/main/java/com/backend/doyouhave/controller/CommentController.java
@@ -1,17 +1,12 @@
 package com.backend.doyouhave.controller;
 
-import com.backend.doyouhave.domain.comment.Comment;
 import com.backend.doyouhave.domain.comment.dto.CommentRequestDto;
+import com.backend.doyouhave.domain.comment.dto.CommentInfoDto;
 import com.backend.doyouhave.domain.comment.dto.CommentResponseDto;
 import com.backend.doyouhave.domain.comment.dto.MyInfoCommentResponseDto;
 import com.backend.doyouhave.domain.post.dto.PostResponseDto;
-import com.backend.doyouhave.domain.user.User;
 import com.backend.doyouhave.service.CommentService;
-import com.backend.doyouhave.service.PostService;
-import com.backend.doyouhave.service.UserService;
-import com.backend.doyouhave.service.result.MultipleResult;
 import com.backend.doyouhave.service.result.ResponseService;
-import com.backend.doyouhave.service.result.Result;
 import com.backend.doyouhave.service.result.SingleResult;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -22,10 +17,11 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/users")
@@ -83,13 +79,13 @@ public class CommentController {
     /* 댓글 목록 반환 API */
     @GetMapping("/posts/{postId}/comments")
     @ApiOperation(value = "댓글 목록 반환")
-    public ResponseEntity<?> getCommentsByPost(
+    public ResponseEntity<SingleResult<CommentResponseDto>> getCommentsByPost(
             @PathVariable("postId") Long postId,
             @AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : #this") Long userId,
             @PageableDefault(size=10) Pageable pageable
     ) {
-        Page<CommentResponseDto> commentsByPost = commentService.getCommentsByPost(postId, userId, pageable);
-
-        return ResponseEntity.ok(commentsByPost);
+        boolean isWriter = commentService.checkUserIsWriter(postId, userId);
+        Page<CommentInfoDto> commentsByPost = commentService.getCommentsByPost(postId, userId, pageable);
+        return ResponseEntity.ok(responseService.getSingleResult(CommentResponseDto.from(isWriter, commentsByPost)));
     }
 }

--- a/src/main/java/com/backend/doyouhave/controller/CommentController.java
+++ b/src/main/java/com/backend/doyouhave/controller/CommentController.java
@@ -15,6 +15,7 @@ import com.backend.doyouhave.service.result.Result;
 import com.backend.doyouhave.service.result.SingleResult;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -82,13 +83,13 @@ public class CommentController {
     /* 댓글 목록 반환 API */
     @GetMapping("/posts/{postId}/comments")
     @ApiOperation(value = "댓글 목록 반환")
-    public ResponseEntity<SingleResult<PostResponseDto>> getCommentsByPost(
+    public ResponseEntity<?> getCommentsByPost(
             @PathVariable("postId") Long postId,
             @AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : #this") Long userId,
             @PageableDefault(size=10) Pageable pageable
     ) {
-        commentService.getCommentsByPost(postId, userId, pageable);
+        Page<CommentResponseDto> commentsByPost = commentService.getCommentsByPost(postId, userId, pageable);
 
-        return ResponseEntity.ok(responseService.getSingleResult(new PostResponseDto(postId)));
+        return ResponseEntity.ok(commentsByPost);
     }
 }

--- a/src/main/java/com/backend/doyouhave/controller/CommentController.java
+++ b/src/main/java/com/backend/doyouhave/controller/CommentController.java
@@ -78,4 +78,17 @@ public class CommentController {
 
         return ResponseEntity.ok(commentService.findByUser(userId, pageable));
     }
+
+    /* 댓글 목록 반환 API */
+    @GetMapping("/posts/{postId}/comments")
+    @ApiOperation(value = "댓글 목록 반환")
+    public ResponseEntity<SingleResult<PostResponseDto>> getCommentsByPost(
+            @PathVariable("postId") Long postId,
+            @AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : #this") Long userId,
+            @PageableDefault(size=10) Pageable pageable
+    ) {
+        commentService.getCommentsByPost(postId, userId, pageable);
+
+        return ResponseEntity.ok(responseService.getSingleResult(new PostResponseDto(postId)));
+    }
 }

--- a/src/main/java/com/backend/doyouhave/domain/comment/dto/ChildCommentDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/comment/dto/ChildCommentDto.java
@@ -1,8 +1,6 @@
 package com.backend.doyouhave.domain.comment.dto;
 
 import com.backend.doyouhave.domain.comment.Comment;
-import com.backend.doyouhave.domain.post.Post;
-import com.backend.doyouhave.domain.post.dto.PostInfoDto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -13,16 +11,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 @Getter
-@Schema(description = "CommentResponseDTO")
-@ApiModel(description = "CommentResponseDTO")
+@Schema(description = "ChildCommentDto")
+@ApiModel(description = "ChildCommentDto")
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class CommentResponseDto {
+public class ChildCommentDto {
 
     @ApiModelProperty(value = "댓글 아이디", required = true, example = "1")
     @Schema(description = "댓글 아이디")
@@ -57,12 +52,8 @@ public class CommentResponseDto {
     @Schema(description = "댓글 작성자 유무", required = true)
     private Boolean isCommentWriter;
 
-    @ApiModelProperty(value = "대댓글 목록 (1단계만)", required = true)
-    @Schema(description = "대댓글 목록 (1단계만)", required = true)
-    private List<ChildCommentDto> childComments = new ArrayList<>();
-
     @Builder
-    public CommentResponseDto(Comment comment, Long userId, String name) {
+    public ChildCommentDto(Comment comment, Long userId, String name) {
         this.commentId = comment.getId();
         this.createdDate = comment.getCreatedDate();
         this.name = name;
@@ -73,12 +64,11 @@ public class CommentResponseDto {
         this.isCommentWriter = userId != null && Objects.equals(comment.getUser().getId(), userId); // 댓글 작성자 id
     }
 
-    public static CommentResponseDto from(Comment comment, Long userId, String name) {
-        return CommentResponseDto.builder()
+    public static ChildCommentDto from(Comment comment, Long userId, String name) {
+        return ChildCommentDto.builder()
                 .comment(comment)
                 .userId(userId)
                 .name(name)
                 .build();
     }
-
 }

--- a/src/main/java/com/backend/doyouhave/domain/comment/dto/CommentInfoDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/comment/dto/CommentInfoDto.java
@@ -11,13 +11,15 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 @Getter
-@Schema(description = "ChildCommentDto")
-@ApiModel(description = "ChildCommentDto")
+@Schema(description = "CommentInfoDto")
+@ApiModel(description = "CommentInfoDto")
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class ChildCommentDto {
+public class CommentInfoDto {
 
     @ApiModelProperty(value = "댓글 아이디", required = true, example = "1")
     @Schema(description = "댓글 아이디")
@@ -36,20 +38,24 @@ public class ChildCommentDto {
     @Schema(description = "댓글 내용")
     private String content;
 
-    @ApiModelProperty(value = "삭제되었는지 여부", required = true, example = "true")
+    @ApiModelProperty(value = "삭제되었는지 여부 (true라면 content='삭제된 댓글입니다')", required = true, example = "true")
     @Schema(description = "삭제 여부", required = true)
     private Boolean isRemoved;
 
-    @ApiModelProperty(value = "비밀댓글인지 여부", required = true, example = "true")
+    @ApiModelProperty(value = "비밀댓글인지 여부 (true라면 글쓴이와 본인만 확인 가능)", required = true, example = "true")
     @Schema(description = "비밀댓글 여부", required = true)
     private Boolean isSecret;
 
-    @ApiModelProperty(value = "댓글 작성자 유무", required = true, example = "true")
-    @Schema(description = "댓글 작성자 유무", required = true)
+    @ApiModelProperty(value = "현재 유저가 댓글 작성자인지 유무", required = true, example = "true")
+    @Schema(description = "현재 유저가 댓글 작성자인지 유무", required = true)
     private Boolean isCommentWriter;
 
+    @ApiModelProperty(value = "대댓글 목록 (1단계만)", required = true)
+    @Schema(description = "대댓글 목록 (1단계만)", required = true)
+    private List<ChildCommentDto> childComments = new ArrayList<>();
+
     @Builder
-    public ChildCommentDto(Comment comment, Long userId, String name, Boolean isParentCommentWriter) {
+    public CommentInfoDto(Comment comment, Long userId, String name) {
         this.commentId = comment.getId();
         this.createdDate = comment.getCreatedDate();
         this.name = name;
@@ -60,15 +66,15 @@ public class ChildCommentDto {
 
         this.content = comment.getContent();
         if (comment.isRemoved()) this.content = "삭제된 댓글입니다.";
-        else if (comment.isSecret() && !isWriter && !isCommentWriter && !isParentCommentWriter) this.content = "비밀 댓글입니다.";
+        else if (comment.isSecret() && (!isWriter && !isCommentWriter)) this.content = "비밀 댓글입니다.";
     }
 
-    public static ChildCommentDto from(Comment comment, Long userId, String name, Boolean isParentCommentWriter) {
-        return ChildCommentDto.builder()
+    public static CommentInfoDto from(Comment comment, Long userId, String name) {
+        return CommentInfoDto.builder()
                 .comment(comment)
                 .userId(userId)
                 .name(name)
-                .isParentCommentWriter(isParentCommentWriter)
                 .build();
     }
+
 }

--- a/src/main/java/com/backend/doyouhave/domain/comment/dto/CommentResponseDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/comment/dto/CommentResponseDto.java
@@ -1,9 +1,6 @@
 package com.backend.doyouhave.domain.comment.dto;
 
 import com.backend.doyouhave.domain.comment.Comment;
-import com.backend.doyouhave.domain.post.Post;
-import com.backend.doyouhave.domain.post.dto.PostInfoDto;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -11,12 +8,9 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 @Getter
 @Schema(description = "CommentResponseDTO")
@@ -24,61 +18,24 @@ import java.util.stream.Collectors;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CommentResponseDto {
 
-    @ApiModelProperty(value = "댓글 아이디", required = true, example = "1")
-    @Schema(description = "댓글 아이디")
-    private Long commentId;
-
-    @ApiModelProperty(value = "댓글 생성 날짜", required = true, example = "2022~")
-    @Schema(description = "댓글 생성 날짜")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
-    private LocalDateTime createdDate;
-
-    @ApiModelProperty(value = "작성자 별명", required = true, example = "익명1")
-    @Schema(description = "작성자 별명")
-    private String name;
-
-    @ApiModelProperty(value = "댓글 내용", required = true, example = "댓글 내용 예시")
-    @Schema(description = "댓글 내용")
-    private String content;
-
-    @ApiModelProperty(value = "삭제되었는지 여부", required = true, example = "true")
-    @Schema(description = "삭제 여부", required = true)
-    private Boolean isRemoved;
-
-    @ApiModelProperty(value = "비밀댓글인지 여부", required = true, example = "true")
-    @Schema(description = "비밀댓글 여부", required = true)
-    private Boolean isSecret;
-
-    @ApiModelProperty(value = "전단지 작성자 유무 (true라면 name='글쓴이'", required = true, example = "true")
-    @Schema(description = "전단지 작성자 유무", required = true)
+    @ApiModelProperty(value = "해당 유저가 게시글 작성자인지 유무", required = true, example = "true")
+    @Schema(description = "해당 유저가 게시글 작성자인지 유무")
     private Boolean isWriter;
 
-    @ApiModelProperty(value = "댓글 작성자 유무", required = true, example = "true")
-    @Schema(description = "댓글 작성자 유무", required = true)
-    private Boolean isCommentWriter;
-
-    @ApiModelProperty(value = "대댓글 목록 (1단계만)", required = true)
-    @Schema(description = "대댓글 목록 (1단계만)", required = true)
-    private List<ChildCommentDto> childComments = new ArrayList<>();
+    @ApiModelProperty(value = "댓글 목록 (페이징)", required = true)
+    @Schema(description = "댓글 목록 (페이징)")
+    private Page<CommentInfoDto> comments;
 
     @Builder
-    public CommentResponseDto(Comment comment, Long userId, String name) {
-        this.commentId = comment.getId();
-        this.createdDate = comment.getCreatedDate();
-        this.name = name;
-        this.content = comment.getContent();
-        this.isRemoved = comment.isRemoved();
-        this.isSecret = comment.isSecret();
-        this.isWriter = userId != null && Objects.equals(comment.getPost().getUser().getId(), userId); // 글쓴이 id
-        this.isCommentWriter = userId != null && Objects.equals(comment.getUser().getId(), userId); // 댓글 작성자 id
+    public CommentResponseDto(boolean isWriter, Page<CommentInfoDto> comments) {
+        this.isWriter = isWriter;
+        this.comments = comments;
     }
 
-    public static CommentResponseDto from(Comment comment, Long userId, String name) {
+    public static CommentResponseDto from(boolean isWriter, Page<CommentInfoDto> comments) {
         return CommentResponseDto.builder()
-                .comment(comment)
-                .userId(userId)
-                .name(name)
+                .isWriter(isWriter)
+                .comments(comments)
                 .build();
     }
-
 }

--- a/src/main/java/com/backend/doyouhave/repository/comment/CommentRepository.java
+++ b/src/main/java/com/backend/doyouhave/repository/comment/CommentRepository.java
@@ -15,4 +15,5 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findByUser(User user);
     List<Comment> findByPost(Post post);
+    List<Comment> findByPostOrderByCreatedDate(Post post);
 }

--- a/src/main/java/com/backend/doyouhave/service/CommentService.java
+++ b/src/main/java/com/backend/doyouhave/service/CommentService.java
@@ -1,17 +1,21 @@
 package com.backend.doyouhave.service;
 
 import com.backend.doyouhave.domain.comment.Comment;
+import com.backend.doyouhave.domain.comment.dto.ChildCommentDto;
 import com.backend.doyouhave.domain.comment.dto.CommentRequestDto;
 import com.backend.doyouhave.domain.comment.dto.CommentResponseDto;
 import com.backend.doyouhave.domain.comment.dto.MyInfoCommentResponseDto;
 import com.backend.doyouhave.domain.notification.Notification;
 import com.backend.doyouhave.domain.post.Post;
 import com.backend.doyouhave.domain.user.User;
+import com.backend.doyouhave.exception.BusinessException;
+import com.backend.doyouhave.exception.ExceptionCode;
 import com.backend.doyouhave.exception.NotFoundException;
 import com.backend.doyouhave.repository.comment.CommentRepository;
 import com.backend.doyouhave.repository.notification.NotificationRepository;
 import com.backend.doyouhave.repository.post.PostRepository;
 import com.backend.doyouhave.repository.user.UserRepository;
+import com.backend.doyouhave.service.sorttype.SortWay;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -19,8 +23,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -99,14 +102,32 @@ public class CommentService {
      */
     public Page<CommentResponseDto> getCommentsByPost(Long postId, Long userId, Pageable pageable) {
         Post post = postRepository.findById(postId).orElseThrow(NotFoundException::new);
-        List<Comment> commentList = commentRepository.findByPost(post);
-        List<CommentResponseDto> commentDtos = new ArrayList<>();
-
+        List<Comment> commentList = commentRepository.findByPostOrderByCreatedDate(post);
+        Map<Long, String> writeCommentUserIdAndNameMap = new HashMap<>(); //U (댓글 작성자들 목록)
+        Map<Long, CommentResponseDto> commentIdAndDtoMap = new LinkedHashMap<>(); //R
+        
         for (Comment comment : commentList) {
-//            commentDtos.add(CommentResponseDto.from(comment, userId, ));
-        }
+            User commentWriter = comment.getUser();
+            boolean isWriter = Objects.equals(commentWriter, comment.getPost().getUser());
+            String name = isWriter ? "글쓴이" : writeCommentUserIdAndNameMap.computeIfAbsent(commentWriter.getId(), key -> "익명"+String.valueOf(writeCommentUserIdAndNameMap.size()+1));
 
-        return new PageImpl<>(commentDtos, pageable, commentDtos.size());
+            if (comment.getParentId() != null) {
+                // 부모 존재
+                CommentResponseDto parentComment = commentIdAndDtoMap.getOrDefault(comment.getParentId(), null);
+//                System.out.println("comment.getId() = " + comment.getId());
+                if (parentComment == null) throw new BusinessException(ExceptionCode.INTERNAL_SERVER_ERROR);
+                parentComment.getChildComments().add(ChildCommentDto.from(comment, userId, name));
+            }
+
+            else {
+                commentIdAndDtoMap.put(comment.getId(), CommentResponseDto.from(comment, userId, name));
+                System.out.println("comment.getId() = " + comment.getId());
+
+            }
+        }
+        System.out.println("writeCommentUserIdAndNameMap = " + writeCommentUserIdAndNameMap);
+        System.out.println("commentIdAndDtoMap = " + commentIdAndDtoMap);
+        return new PageImpl<>(new ArrayList<>(commentIdAndDtoMap.values()), pageable, commentIdAndDtoMap.size());
     }
 
     /*

--- a/src/main/java/com/backend/doyouhave/service/CommentService.java
+++ b/src/main/java/com/backend/doyouhave/service/CommentService.java
@@ -97,11 +97,13 @@ public class CommentService {
     /*
      * 전단지에 작성된 댓글
      */
-    public Page<CommentResponseDto> findByPost(Post post, Pageable pageable, User writer, User user) {
+    public Page<CommentResponseDto> getCommentsByPost(Long postId, Long userId, Pageable pageable) {
+        Post post = postRepository.findById(postId).orElseThrow(NotFoundException::new);
+        List<Comment> commentList = commentRepository.findByPost(post);
         List<CommentResponseDto> commentDtos = new ArrayList<>();
 
-        for (Comment comment : commentRepository.findByPost(post)) {
-            commentDtos.add(new CommentResponseDto(comment));
+        for (Comment comment : commentList) {
+//            commentDtos.add(CommentResponseDto.from(comment, userId, ));
         }
 
         return new PageImpl<>(commentDtos, pageable, commentDtos.size());

--- a/src/main/java/com/backend/doyouhave/service/PostService.java
+++ b/src/main/java/com/backend/doyouhave/service/PostService.java
@@ -1,6 +1,5 @@
 package com.backend.doyouhave.service;
 
-import com.backend.doyouhave.domain.comment.dto.CommentResponseDto;
 import com.backend.doyouhave.domain.post.Category;
 import com.backend.doyouhave.domain.post.Post;
 import com.backend.doyouhave.domain.post.dto.PostInfoDto;
@@ -25,7 +24,6 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Transactional
 @RequiredArgsConstructor


### PR DESCRIPTION
**댓글 목록 반환 API**를 개발했습니다.
{ isWriter: boolean , comments: page<> } 타입으로 구현했습니다.
댓글 작성일 순으로 정렬해 **익명 순서**를 계산했습니다. (글쓴이, 익명1, 익명2...)
**대댓글**의 경우 원댓글 데이터의 childComments 배열에 담았습니다.

> 삭제된 댓글 : "삭제된 댓글입니다."

> 비밀 댓글 : "비밀 댓글입니다." (게시글 작성자, 댓글 작성자, 원댓글 작성자의 경우 댓글 내용을 볼 수 있음)
