### PR TITLE
Feat: 사용자 로그아웃 및 탈퇴 API

### DIFF
--- a/src/main/java/com/backend/doyouhave/controller/UserController.java
+++ b/src/main/java/com/backend/doyouhave/controller/UserController.java
@@ -2,6 +2,7 @@ package com.backend.doyouhave.controller;
 
 import com.backend.doyouhave.domain.notification.dto.NotificationResponseDto;
 import com.backend.doyouhave.domain.post.dto.PostListResponseDto;
+import com.backend.doyouhave.domain.resign.dto.ResignRequestDto;
 import com.backend.doyouhave.domain.user.Role;
 import com.backend.doyouhave.domain.user.dto.KakaoLoginRequestDto;
 import com.backend.doyouhave.domain.user.dto.LoginResponseDto;
@@ -97,8 +98,9 @@ public class UserController {
 
     @PostMapping("/resign")
     @ApiOperation(value = "회원탈퇴 API", notes = "탈퇴사유를 저장하고 사용자 데이터는 삭제한다.")
-    public ResponseEntity<Result> deleteUser(@AuthenticationPrincipal Long userId) {
-
+    public ResponseEntity<Result> deleteUser(@AuthenticationPrincipal Long userId, @RequestBody @Valid ResignRequestDto request) {
+        userService.deleteUser(userId);
+        userService.saveResignReason(request.getReason());
         return ResponseEntity.ok(responseService.getSuccessResult());
     }
 }

--- a/src/main/java/com/backend/doyouhave/controller/UserController.java
+++ b/src/main/java/com/backend/doyouhave/controller/UserController.java
@@ -11,10 +11,7 @@ import com.backend.doyouhave.exception.ExceptionCode;
 import com.backend.doyouhave.exception.ExceptionResponse;
 import com.backend.doyouhave.service.PostService;
 import com.backend.doyouhave.service.UserService;
-import com.backend.doyouhave.service.result.MultiplePageResult;
-import com.backend.doyouhave.service.result.MultipleResult;
-import com.backend.doyouhave.service.result.ResponseService;
-import com.backend.doyouhave.service.result.SingleResult;
+import com.backend.doyouhave.service.result.*;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -89,5 +86,12 @@ public class UserController {
             @PageableDefault(size = 20) Pageable pageable) {
         Page<PostListResponseDto> postListResponseDtos = userService.marksList(userId, pageable);
         return ResponseEntity.ok(responseService.getMultiplePageResult(postListResponseDtos));
+    }
+
+    @PostMapping("/logout")
+    @ApiOperation(value = "로그아웃 API", notes = "DB의 refresh token을 삭제한다.")
+    public ResponseEntity<Result> logoutUser(@AuthenticationPrincipal Long userId) {
+        userService.deleteRefreshToken(userId);
+        return ResponseEntity.ok(responseService.getSuccessResult());
     }
 }

--- a/src/main/java/com/backend/doyouhave/controller/UserController.java
+++ b/src/main/java/com/backend/doyouhave/controller/UserController.java
@@ -94,4 +94,11 @@ public class UserController {
         userService.deleteRefreshToken(userId);
         return ResponseEntity.ok(responseService.getSuccessResult());
     }
+
+    @PostMapping("/resign")
+    @ApiOperation(value = "회원탈퇴 API", notes = "탈퇴사유를 저장하고 사용자 데이터는 삭제한다.")
+    public ResponseEntity<Result> deleteUser(@AuthenticationPrincipal Long userId) {
+
+        return ResponseEntity.ok(responseService.getSuccessResult());
+    }
 }

--- a/src/main/java/com/backend/doyouhave/domain/resign/ResignReason.java
+++ b/src/main/java/com/backend/doyouhave/domain/resign/ResignReason.java
@@ -25,7 +25,7 @@ public class ResignReason extends BaseTimeEntity {
     private String reason;
 
     @Column(nullable = false)
-    private int count = 0;
+    private int count = 1;
 
     @Builder
     public ResignReason(String reason) {

--- a/src/main/java/com/backend/doyouhave/domain/resign/ResignReason.java
+++ b/src/main/java/com/backend/doyouhave/domain/resign/ResignReason.java
@@ -1,0 +1,40 @@
+package com.backend.doyouhave.domain.resign;
+
+import com.backend.doyouhave.domain.BaseTimeEntity;
+import com.backend.doyouhave.domain.user.dto.LoginResponseDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Embeddable
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Entity
+public class ResignReason extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "resign_reason_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String reason;
+
+    @Column(nullable = false)
+    private int count = 0;
+
+    @Builder
+    public ResignReason(String reason) {
+        this.reason = reason;
+    }
+
+    public static ResignReason from(String reason) {
+        return ResignReason.builder()
+                .reason(reason)
+                .build();
+    }
+}

--- a/src/main/java/com/backend/doyouhave/domain/resign/dto/ResignRequestDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/resign/dto/ResignRequestDto.java
@@ -1,5 +1,6 @@
 package com.backend.doyouhave.domain.resign.dto;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,6 +10,8 @@ import javax.validation.constraints.NotBlank;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ResignRequestDto {
+
+    @ApiModelProperty(value = "탈퇴 사유")
     @NotBlank
     private String reason;
 }

--- a/src/main/java/com/backend/doyouhave/domain/resign/dto/ResignRequestDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/resign/dto/ResignRequestDto.java
@@ -1,0 +1,14 @@
+package com.backend.doyouhave.domain.resign.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ResignRequestDto {
+    @NotBlank
+    private String reason;
+}

--- a/src/main/java/com/backend/doyouhave/domain/user/dto/KakaoLoginRequestDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/user/dto/KakaoLoginRequestDto.java
@@ -1,5 +1,6 @@
 package com.backend.doyouhave.domain.user.dto;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,6 +10,7 @@ import javax.validation.constraints.NotBlank;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class KakaoLoginRequestDto {
+    @ApiModelProperty(value = "카카오 서버 토큰")
     @NotBlank
     private String code;
 }

--- a/src/main/java/com/backend/doyouhave/domain/user/dto/LoginResponseDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/user/dto/LoginResponseDto.java
@@ -1,5 +1,6 @@
 package com.backend.doyouhave.domain.user.dto;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,9 +11,11 @@ import javax.validation.constraints.NotBlank;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class LoginResponseDto {
+    @ApiModelProperty(value = "accessToken")
     @NotBlank
     private String accessToken;
 
+    @ApiModelProperty(value = "refreshToken")
     @NotBlank
     private String refreshToken;
 

--- a/src/main/java/com/backend/doyouhave/domain/user/dto/NaverLoginRequestDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/user/dto/NaverLoginRequestDto.java
@@ -1,5 +1,6 @@
 package com.backend.doyouhave.domain.user.dto;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,9 +10,11 @@ import javax.validation.constraints.NotBlank;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class NaverLoginRequestDto {
+    @ApiModelProperty(value = "네이버 서버 토큰")
     @NotBlank
     private String code;
 
+    @ApiModelProperty(value = "네이버 로그인 state")
     @NotBlank
     private String state;
 }

--- a/src/main/java/com/backend/doyouhave/domain/user/dto/TokenRefreshRequestDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/user/dto/TokenRefreshRequestDto.java
@@ -1,5 +1,6 @@
 package com.backend.doyouhave.domain.user.dto;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,6 +10,7 @@ import javax.validation.constraints.NotBlank;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TokenRefreshRequestDto {
+    @ApiModelProperty(value = "refreshToken")
     @NotBlank
     private String refreshToken;
 }

--- a/src/main/java/com/backend/doyouhave/domain/user/dto/UserProfileResponseDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/user/dto/UserProfileResponseDto.java
@@ -1,6 +1,7 @@
 package com.backend.doyouhave.domain.user.dto;
 
 import com.backend.doyouhave.domain.user.User;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,18 +12,23 @@ import javax.validation.constraints.NotBlank;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserProfileResponseDto {
+    @ApiModelProperty(value = "사용자 id")
     @NotBlank
     private Long userId;
 
+    @ApiModelProperty(value = "이메일")
     @NotBlank
     private String email;
 
+    @ApiModelProperty(value = "프로필 사진")
     @NotBlank
     private String img;
 
+    @ApiModelProperty(value = "닉네임 (소셜 계정 이름)")
     @NotBlank
     private String nickname;
 
+    @ApiModelProperty(value = "소셜 로그인 유형 (카카오/네이버)")
     @NotBlank
     private String socialType;
 

--- a/src/main/java/com/backend/doyouhave/repository/resign/ResignReasonRepository.java
+++ b/src/main/java/com/backend/doyouhave/repository/resign/ResignReasonRepository.java
@@ -1,0 +1,12 @@
+package com.backend.doyouhave.repository.resign;
+
+import com.backend.doyouhave.domain.resign.ResignReason;
+import com.backend.doyouhave.domain.user.Role;
+import com.backend.doyouhave.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ResignReasonRepository extends JpaRepository<ResignReason, Long> {
+    Optional<ResignReason> findByReason(String reason);
+}

--- a/src/main/java/com/backend/doyouhave/service/AuthService.java
+++ b/src/main/java/com/backend/doyouhave/service/AuthService.java
@@ -74,7 +74,6 @@ public class AuthService {
 
             JSONParser parser = new JSONParser();
             JSONObject elem = (JSONObject) parser.parse(response.getBody());
-            System.out.println("elem = " + elem);
             accessToken = (String) elem.get("access_token");
         } catch (Exception e) {
             throw new SocialLoginException();
@@ -140,7 +139,6 @@ public class AuthService {
 
             JSONParser parser = new JSONParser();
             JSONObject elem = (JSONObject) parser.parse(response.getBody());
-            System.out.println("elem = " + elem);
             accessToken = (String) elem.get("access_token");
         } catch (Exception e) {
             throw new SocialLoginException();

--- a/src/main/java/com/backend/doyouhave/service/UserService.java
+++ b/src/main/java/com/backend/doyouhave/service/UserService.java
@@ -3,6 +3,7 @@ package com.backend.doyouhave.service;
 import com.backend.doyouhave.domain.comment.dto.CommentRequestDto;
 import com.backend.doyouhave.domain.notification.Notification;
 import com.backend.doyouhave.domain.notification.dto.NotificationResponseDto;
+import com.backend.doyouhave.domain.post.Post;
 import com.backend.doyouhave.domain.post.dto.PostListResponseDto;
 import com.backend.doyouhave.domain.user.Role;
 import com.backend.doyouhave.domain.user.User;
@@ -90,5 +91,9 @@ public class UserService {
                 .findMarkedPostByUserId(userId, pageable)
                 .map(PostListResponseDto::new);
         return markedPostResponseDtos;
+    }
+
+    public void deleteRefreshToken(Long userId) {
+        authService.updateRefreshToken(userId, null);
     }
 }


### PR DESCRIPTION
**사용자 로그아웃 API** : 따로 구현하지 않아도 될 것 같지만, 임시로 구현해 두었습니다. DB의 refreshToken을 삭제하는 로직입니다.
**사용자 탈퇴 API** : 사용자 데이터를 삭제하고 탈퇴 사유 DB에 사유 기재 및 count 계산을 진행합니다.