### PR TITLE
feat: 관리자 페이지 회원 목록 API, 신고 전단지 목록 API 추가

### DIFF
--- a/src/main/java/com/backend/doyouhave/config/SecurityConfig.java
+++ b/src/main/java/com/backend/doyouhave/config/SecurityConfig.java
@@ -18,6 +18,11 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Collections;
 
 @RequiredArgsConstructor
 @EnableWebSecurity
@@ -43,19 +48,19 @@ public class SecurityConfig {
                 "/webjars/**",
                 "/api/users/kakao-login",
                 "/api/users/naver-login",
-                "/api/auth/token-refresh"
-        ).mvcMatchers(HttpMethod.GET, "/api/users/posts/**");
-
+                "/api/auth/token-refresh")
+                .mvcMatchers(HttpMethod.GET, "/api/users/posts/**");
     }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        return http.csrf().disable()
+        return http
+                .cors().and()
+                .csrf().disable()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
 
                 .authorizeRequests()
-                .antMatchers("/api/admins/**").hasRole("ADMIN")
                 .antMatchers("/swagger-resources/**").permitAll()
                 .anyRequest().authenticated()
                 .and()
@@ -87,5 +92,20 @@ public class SecurityConfig {
                             ExceptionResponse.of(ExceptionCode.FAIL_AUTHORIZATION)
                     );
                 })).and().build();
+    }
+
+    // Cors 설정
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.setAllowedOriginPatterns(Collections.singletonList("*"));
+        configuration.addAllowedHeader("*");
+        configuration.addAllowedMethod("*");
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/src/main/java/com/backend/doyouhave/controller/ManagerController.java
+++ b/src/main/java/com/backend/doyouhave/controller/ManagerController.java
@@ -1,0 +1,48 @@
+package com.backend.doyouhave.controller;
+
+import com.backend.doyouhave.domain.post.dto.ReportedPostDto;
+import com.backend.doyouhave.domain.user.dto.UserInfoDto;
+import com.backend.doyouhave.service.PostService;
+import com.backend.doyouhave.service.UserService;
+import com.backend.doyouhave.service.result.MultiplePageResult;
+import com.backend.doyouhave.service.result.MultipleResult;
+import com.backend.doyouhave.service.result.ResponseService;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("api/admins")
+@RestController
+public class ManagerController {
+
+    private final UserService userService;
+    private final PostService postService;
+    private final ResponseService responseService;
+
+    @GetMapping("/users")
+    @ApiOperation(value = "회원 목록 API", notes = "관리자 페이지에서 회원 목록을 보여준다. (회원정보, 접속일자)")
+    public ResponseEntity<MultiplePageResult<UserInfoDto>> usersInfo(
+            @PageableDefault(sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<UserInfoDto> userInfoDtos = userService.findUsersInfo(pageable);
+        return ResponseEntity.ok(responseService.getMultiplePageResult(userInfoDtos));
+    }
+
+    @GetMapping("/posts/report")
+    @ApiOperation(value = "신고 글 목록 API", notes = "관리자 페이지에서 신고당한 글 목록을 보여준다. ")
+    public ResponseEntity<MultiplePageResult<ReportedPostDto>> reportedPostInfo(
+            @PageableDefault(sort = "created_date", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<ReportedPostDto> reportedPostDtos = postService.findReportedPosts(pageable);
+        return ResponseEntity.ok(responseService.getMultiplePageResult(reportedPostDtos));
+    }
+}
+

--- a/src/main/java/com/backend/doyouhave/domain/post/dto/ReportedPostDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/post/dto/ReportedPostDto.java
@@ -1,0 +1,31 @@
+package com.backend.doyouhave.domain.post.dto;
+
+import com.backend.doyouhave.domain.post.Post;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor
+public class ReportedPostDto {
+
+    @ApiModelProperty(value = "전단지 아이디")
+    @NotBlank
+    private Long postId;
+
+    @ApiModelProperty(value = "전단지 제목")
+    @NotBlank
+    private String title;
+
+    @ApiModelProperty(value = "전단지 작성자 이메일")
+    @NotBlank
+    private String writerEmail;
+
+    public ReportedPostDto(Post reportedPost) {
+        this.postId = reportedPost.getId();
+        this.title = reportedPost.getTitle();
+        this.writerEmail = reportedPost.getUser().getEmail();
+    }
+}

--- a/src/main/java/com/backend/doyouhave/domain/user/User.java
+++ b/src/main/java/com/backend/doyouhave/domain/user/User.java
@@ -10,6 +10,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,6 +51,14 @@ public class User extends BaseTimeEntity {
     @Column(name = "refresh_token")
     private String refreshToken;
 
+    // 최근 접속일자 (로그인시 LocalDateTime.now()로 업데이트)
+    private LocalDateTime recentDate;
+
+    // 회원 상태
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserState userState;
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<Comment> comments = new ArrayList<>();
 
@@ -72,6 +81,7 @@ public class User extends BaseTimeEntity {
                 .img(img)
                 .nickname(nickname)
                 .role(Role.KAKAO)
+                .userState(UserState.NORMAL)
                 .build();
     }
 
@@ -82,6 +92,7 @@ public class User extends BaseTimeEntity {
                 .img(img)
                 .nickname(nickname)
                 .role(Role.NAVER)
+                .userState(UserState.NORMAL)
                 .build();
     }
 }

--- a/src/main/java/com/backend/doyouhave/domain/user/UserState.java
+++ b/src/main/java/com/backend/doyouhave/domain/user/UserState.java
@@ -1,0 +1,13 @@
+package com.backend.doyouhave.domain.user;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserState {
+    NORMAL("NORMAL"),
+    SUSPENDED("SUSPENDED");
+
+    private final String value;
+}

--- a/src/main/java/com/backend/doyouhave/domain/user/dto/UserInfoDto.java
+++ b/src/main/java/com/backend/doyouhave/domain/user/dto/UserInfoDto.java
@@ -1,0 +1,45 @@
+package com.backend.doyouhave.domain.user.dto;
+
+import com.backend.doyouhave.domain.user.User;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@NoArgsConstructor
+public class UserInfoDto {
+
+    @ApiModelProperty(value = "이메일")
+    @NotBlank
+    private String email;
+
+    @ApiModelProperty(value = "닉네임 (소셜 계정 이름)")
+    @NotBlank
+    private String nickname;
+
+    @ApiModelProperty(value = "가입 일자")
+    @NotBlank
+    private String signupDate;
+
+    @ApiModelProperty(value = "최근 접속 일자")
+    @NotBlank
+    private String recentDate;
+
+    @ApiModelProperty(value = "상태(정상, 이용 제한)")
+    @NotBlank
+    private String userState;
+
+    public UserInfoDto (User user) {
+        this.email = user.getEmail();
+        this.nickname = user.getNickname();
+        this.signupDate = String.valueOf(user.getCreatedDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        this.recentDate = String.valueOf(user.getRecentDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        this.userState = user.getUserState().getValue();
+    }
+}

--- a/src/main/java/com/backend/doyouhave/repository/post/PostRepository.java
+++ b/src/main/java/com/backend/doyouhave/repository/post/PostRepository.java
@@ -25,4 +25,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     /* 북마크한 전단지 조회 */
     @Query(value = "select * from Post p left join user_likes u on p.post_id = u.post_id where u.user_id = :userId order by u.created_date desc", nativeQuery = true)
     Page<Post> findMarkedPostByUserId(@Param("userId") Long userId, Pageable pageable);
+
+    @Query(value = "select * from Post p where p.reported_count > 0", nativeQuery = true)
+    Page<Post> findAllByReportedPost(Pageable pageable);
 }

--- a/src/main/java/com/backend/doyouhave/service/UserService.java
+++ b/src/main/java/com/backend/doyouhave/service/UserService.java
@@ -5,11 +5,13 @@ import com.backend.doyouhave.domain.notification.Notification;
 import com.backend.doyouhave.domain.notification.dto.NotificationResponseDto;
 import com.backend.doyouhave.domain.post.Post;
 import com.backend.doyouhave.domain.post.dto.PostListResponseDto;
+import com.backend.doyouhave.domain.post.dto.ReportedPostDto;
 import com.backend.doyouhave.domain.resign.ResignReason;
 import com.backend.doyouhave.domain.resign.dto.ResignRequestDto;
 import com.backend.doyouhave.domain.user.Role;
 import com.backend.doyouhave.domain.user.User;
 import com.backend.doyouhave.domain.user.dto.LoginResponseDto;
+import com.backend.doyouhave.domain.user.dto.UserInfoDto;
 import com.backend.doyouhave.domain.user.dto.UserProfileResponseDto;
 import com.backend.doyouhave.exception.NotFoundException;
 import com.backend.doyouhave.jwt.JwtTokenProvider;
@@ -23,6 +25,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -66,6 +69,7 @@ public class UserService {
     public LoginResponseDto login(User user) {
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
         authService.updateRefreshToken(user.getId(), refreshToken);
+        user.setRecentDate(LocalDateTime.now());
 
         return LoginResponseDto.from(
                 jwtTokenProvider.createAccessToken(user.getId()),
@@ -116,5 +120,9 @@ public class UserService {
         } else {
             resignReasonRepository.save(ResignReason.from(reason));
         }
+    }
+
+    public Page<UserInfoDto> findUsersInfo(Pageable pageable) {
+        return userRepository.findAll(pageable).map(UserInfoDto::new);
     }
 }


### PR DESCRIPTION
- 관리자 페이지 회원 정보(기본 정보, 제한 상태)에 대한 목록 API와 신고된 전단지 목록 API 추가
- 회원 도메인 최근 접속일자, 제한 상태 필드 추가

- Ajax 통신시 도메인 액세스 허용 처리가 필요하여 SecurityConfig에 Cors 설정을 추가하였습니다.